### PR TITLE
feat(ui): 添加Electron splash启动窗口

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -62,7 +62,8 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),
           standalone: resolve(__dirname, 'src/renderer/standalone.html'),
-          AIbackground: resolve(__dirname, 'src/renderer/AIbackground.html')
+          AIbackground: resolve(__dirname, 'src/renderer/AIbackground.html'),
+          splash: resolve(__dirname, 'src/renderer/splash.html')
         }
       },
     },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,7 @@ import { initUpdaterService } from './services/updaterService';
 import { createCaptureWindowService } from './window/captureWindow';
 import { createMainWindowService } from './window/mainWindow';
 import { openStandaloneWindow } from './window/standaloneWindow';
+import { showSplashWindow, closeSplashWindow } from './window/splashWindow';
 import { createSmtcService } from './music/smtcService';
 import { setSmtcAccessor } from './music/smtcAccessor';
 import { createAutoHideWatcher } from './system/autoHideWatcher';
@@ -348,6 +349,9 @@ const mainWindowService = createMainWindowService({
   sizes: {
     islandWidth: ISLAND_WIDTH,
     islandHeight: ISLAND_HEIGHT,
+  },
+  onBeforeShow: () => {
+    closeSplashWindow();
   },
 });
 
@@ -829,6 +833,7 @@ app.whenReady().then(() => {
   clipboardUrlState.setDetectMode(readClipboardUrlDetectModeConfig());
   clipboardUrlState.setBlacklist(readClipboardUrlBlacklistConfig());
 
+  showSplashWindow();
   mainWindowService.createWindow();
   createTray(mainWindow);
 

--- a/src/main/window/mainWindow.ts
+++ b/src/main/window/mainWindow.ts
@@ -42,6 +42,7 @@ interface CreateMainWindowServiceOptions {
   setIslandPositionOffset: (offset: { x: number; y: number }) => void;
   sanitizeIslandPositionOffset: (offset: { x?: number; y?: number }) => { x: number; y: number };
   sizes: WindowSizeOptions;
+  onBeforeShow?: () => void;
 }
 
 interface MainWindowService {
@@ -151,6 +152,9 @@ export function createMainWindowService(options: CreateMainWindowServiceOptions)
 
     mainWindow.on('ready-to-show', () => {
       mainWindow.setBounds(initialBounds, false);
+      if (options.onBeforeShow) {
+        options.onBeforeShow();
+      }
       mainWindow.show();
       mainWindow.setAlwaysOnTop(true, 'screen-saver');
     });

--- a/src/main/window/splashWindow.ts
+++ b/src/main/window/splashWindow.ts
@@ -1,0 +1,114 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file splashWindow.ts
+ * @description 启动画面窗口服务模块
+ * @description 管理应用启动画面的创建、显示和关闭，在主窗口加载期间提供视觉反馈
+ * @author 鸡哥
+ */
+
+import { BrowserWindow } from 'electron';
+import { join } from 'path';
+import { is } from '@electron-toolkit/utils';
+
+let splashWindow: BrowserWindow | null = null;
+
+/**
+ * 创建并显示启动画面窗口
+ * @description 创建一个无边框、居中的启动画面窗口，显示应用图标和加载动画
+ */
+function showSplashWindow(): void {
+  if (splashWindow && !splashWindow.isDestroyed()) {
+    splashWindow.show();
+    return;
+  }
+
+  splashWindow = new BrowserWindow({
+    width: 400,
+    height: 300,
+    show: false,
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    resizable: false,
+    movable: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    hasShadow: true,
+    icon: is.dev
+      ? join(__dirname, '../../resources/icon/eisland_256x256.ico')
+      : join(process.resourcesPath, 'icon/eisland_256x256.ico'),
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  splashWindow.setAlwaysOnTop(true, 'screen-saver');
+  splashWindow.center();
+  splashWindow.removeMenu();
+
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    splashWindow.loadURL(process.env['ELECTRON_RENDERER_URL'] + '/splash.html');
+  } else {
+    splashWindow.loadFile(join(__dirname, '../renderer/splash.html'));
+  }
+
+  splashWindow.once('ready-to-show', () => {
+    if (splashWindow && !splashWindow.isDestroyed()) {
+      splashWindow.show();
+    }
+  });
+
+  splashWindow.on('closed', () => {
+    splashWindow = null;
+  });
+}
+
+/**
+ * 关闭启动画面窗口
+ * @description 带有淡出动画效果地关闭启动画面窗口
+ */
+function closeSplashWindow(): void {
+  if (splashWindow && !splashWindow.isDestroyed()) {
+    const win = splashWindow;
+    win.webContents.executeJavaScript('startFadeOut()').catch(() => {});
+    setTimeout(() => {
+      if (win && !win.isDestroyed()) {
+        win.close();
+      }
+    }, 300);
+    splashWindow = null;
+  }
+}
+
+/**
+ * 获取启动画面窗口实例
+ */
+function getSplashWindow(): BrowserWindow | null {
+  return splashWindow;
+}
+
+export { showSplashWindow, closeSplashWindow, getSplashWindow };

--- a/src/renderer/splash.html
+++ b/src/renderer/splash.html
@@ -1,0 +1,223 @@
+<!--
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<!--
+  @file splash.html
+  @description 应用启动画面，显示图标、应用名和加载动画
+  @author 鸡哥
+-->
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>eIsland</title>
+<style>
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html, body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+    user-select: none;
+  }
+
+  .splash-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: rgba(20, 20, 22, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-radius: 24px;
+    opacity: 1;
+    transition: opacity 0.3s ease-out;
+  }
+
+  .splash-container.fade-out {
+    opacity: 0;
+  }
+
+  .icon-wrapper {
+    width: 96px;
+    height: 96px;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .icon-wrapper img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    -webkit-user-drag: none;
+  }
+
+  .app-name {
+    font-size: 28px;
+    font-weight: 600;
+    color: #ffffff;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+  }
+
+  .app-subtitle {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.5);
+    margin-bottom: 32px;
+  }
+
+  .loading-pill {
+    width: 120px;
+    height: 36px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 18px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .loading-pill::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.15) 50%,
+      transparent 100%
+    );
+    animation: shimmer 1.8s ease-in-out infinite;
+  }
+
+  .loading-pill-dot {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    gap: 6px;
+  }
+
+  .loading-pill-dot span {
+    width: 6px;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.6);
+    border-radius: 50%;
+    animation: bounce 1.4s ease-in-out infinite both;
+  }
+
+  .loading-pill-dot span:nth-child(1) {
+    animation-delay: -0.32s;
+  }
+
+  .loading-pill-dot span:nth-child(2) {
+    animation-delay: -0.16s;
+  }
+
+  .loading-pill-dot span:nth-child(3) {
+    animation-delay: 0s;
+  }
+
+  @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+
+  @keyframes bounce {
+    0%, 80%, 100% {
+      transform: scale(0.6);
+      opacity: 0.4;
+    }
+    40% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  .version {
+    position: absolute;
+    bottom: 20px;
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.3);
+  }
+</style>
+</head>
+<body>
+  <div class="splash-container" id="splashContainer">
+    <div class="icon-wrapper">
+      <img id="appIcon" alt="eIsland">
+    </div>
+    <div class="app-name">eIsland</div>
+    <div class="app-subtitle">灵动岛 · 正在启动</div>
+    <div class="loading-pill">
+      <div class="loading-pill-dot">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+    </div>
+    <div class="version" id="versionText"></div>
+  </div>
+
+<script>
+  function startFadeOut() {
+    const container = document.getElementById('splashContainer');
+    if (container) {
+      container.classList.add('fade-out');
+    }
+  }
+
+  (function() {
+    const params = new URLSearchParams(window.location.search);
+    const version = params.get('version') || '';
+    const versionEl = document.getElementById('versionText');
+    if (versionEl && version) {
+      versionEl.textContent = 'v' + version;
+    }
+
+    const iconImg = document.getElementById('appIcon');
+    if (iconImg) {
+      iconImg.src = './svg/eisland.svg';
+      iconImg.onerror = function() {
+        iconImg.src = './svg/AI.svg';
+      };
+    }
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 变更说明

- 

## 验证说明

- [√] 本地已完成必要验证（功能/构建/回归）

## 前端规范全量核对（必填）

> 规范文档：`docs/FRONTEND_STANDARDS.md`
>
> 注释规范文档：`docs/COMMENT_STANDARDS.md`
>
> 以下 6 项用于 `PR Code Quality Review` 工作流强校验，必须勾选。

- [√] STD-1-HTML 已核对 docs/FRONTEND_STANDARDS.md 第 1 章 HTML 规范全部条款
- [√] STD-2-CSS 已核对 docs/FRONTEND_STANDARDS.md 第 2 章 CSS 规范全部条款
- [√] STD-3-JSTS 已核对 docs/FRONTEND_STANDARDS.md 第 3 章 JavaScript / TypeScript 规范全部条款
- [√] STD-4-REACT 已核对 docs/FRONTEND_STANDARDS.md 第 4 章 React 规范全部条款
- [√] STD-5-NEXT 已核对 docs/FRONTEND_STANDARDS.md 第 5 章 Next.js 规范全部条款（如适用）
- [√] STD-COMMENT 已核对 docs/COMMENT_STANDARDS.md 注释规范全部条款

## 影响范围

- [√] 渲染层（`src/renderer`）
- [√] 主进程（`src/main`）
- [√] 预加载（`src/preload`）
- [ ] 文档/工作流
- [ ] 其他：

## 改动文件清单
### 新增文件
1. splashWindow.ts - 启动画面窗口服务
   
   - showSplashWindow() - 创建并显示启动画面
   - closeSplashWindow() - 带淡出动画关闭启动画面
   - getSplashWindow() - 获取窗口实例
2. splash.html - 启动画面 UI
   
   - 深色毛玻璃背景 + 24px 圆角
   - eIsland 图标 + 应用名 + "灵动岛 · 正在启动" 副标题
   - 胶囊形加载动画（呼吸光点 + 微光扫过效果）
   - 底部版本号显示
   - 支持淡出动画
### 修改文件
3. electron.vite.config.ts - 添加 splash 构建入口
4. mainWindow.ts - 在 CreateMainWindowServiceOptions 中新增可选的 onBeforeShow 回调，在主窗口显示前触发
5. index.ts - 主进程集成
   
   - 导入 showSplashWindow 和 closeSplashWindow
   - 在 mainWindowService 配置中添加 onBeforeShow 回调以关闭启动画面
   - 在 app.whenReady() 中先调用 showSplashWindow() 再创建主窗口
## 启动流程
```
app.whenReady()
    ↓
显示启动画面 (showSplashWindow)
    ↓ 同时
创建主窗口 (后台加载渲染进程)
    ↓
主窗口 ready-to-show
    ↓
关闭启动画面 (closeSplashWindow, 带淡出)
    ↓
显示主窗口
```
所有 TypeScript 类型检查均已通过 ✅