### PR TITLE
docs: 更新程序和快捷方式图标获取插件相关命令文档

### DIFF
--- a/web/eisland-web-docs/src/api-plugins/system-power/application-icon-helper.md
+++ b/web/eisland-web-docs/src/api-plugins/system-power/application-icon-helper.md
@@ -39,6 +39,10 @@ All icon functions return `IconResult | null`. The result contains PNG image dat
 | `npm run clean` | `dotnet clean` | Clean build artifacts |
 | `npm run rebuild` | `npm run clean && npm run build` | Clean and rebuild |
 
+:::tip
+This plugin is automatically built when running `npm run plugins:build` from the project root. You do not need to build it separately unless working on the plugin in isolation.
+:::
+
 :::warning
 The build requires .NET 10 SDK and Visual Studio Build Tools with C++ workload installed. The Windows SDK path must be correctly configured.
 :::

--- a/web/eisland-web-docs/src/developer/commands/plugin-commands.md
+++ b/web/eisland-web-docs/src/developer/commands/plugin-commands.md
@@ -27,6 +27,7 @@ npm run <script>
 | **SMTC Helper** | `eisland-windows-smtc-helper` | C# | dotnet | ✅ | ✅ |
 | **Bluetooth Helper** | `eisland-windows-bluetooth-helper` | C# | dotnet | ✅ | ✅ |
 | **Brightness Helper** | `eisland-windows-brightness-helper` | C# | dotnet | ✅ | ✅ |
+| **Application Icon Helper** | `eisland-windows-application-icon-helper` | C# | dotnet | ✅ | ✅ |
 
 ## Common Commands
 
@@ -48,8 +49,8 @@ Run from the **project root** to build or clean all plugins at once.
 
 | Command | Description |
 |---------|-------------|
-| `npm run plugins:build` | Build all 9 plugins sequentially (uses `build:all` where available) |
-| `npm run plugins:clean` | Clean all 9 plugins in parallel |
+| `npm run plugins:build` | Build all 10 plugins sequentially (uses `build:all` where available) |
+| `npm run plugins:clean` | Clean all 10 plugins in parallel |
 
 :::tip
 `plugins:build` automatically uses `build:all` for Bluetooth, Power, SMTC, and WiFi Helpers (which include NativeAOT DLL targets). All other plugins use `build`.
@@ -70,6 +71,7 @@ Each plugin also has a dedicated root-level command for targeted builds and clea
 | WiFi Helper | `npm run plugin:build:wifi` | `npm run plugin:clean:wifi` |
 | Fullscreen Detector | `npm run plugin:build:fullscreen` | `npm run plugin:clean:fullscreen` |
 | Performance Monitor | `npm run plugin:build:perfmon` | `npm run plugin:clean:perfmon` |
+| Application Icon Helper | `npm run plugin:build:icon-helper` | `npm run plugin:clean:icon-helper` |
 
 :::info NativeAOT Build Requirement
 Building NativeAOT DLLs (`npm run build:ctypes` for SMTC, Bluetooth, Power, WiFi helpers) requires `vswhere.exe` in PATH. If the build fails with `'vswhere.exe' is not recognized`, add it:
@@ -377,6 +379,41 @@ This is a pure .NET plugin that spawns a console EXE for WMI brightness operatio
 
 ---
 
+## Windows Application Icon Helper
+
+**Directory:** `plugins/eisland-windows-application-icon-helper` &nbsp;|&nbsp; **Language:** C# (.NET) &nbsp;|&nbsp; **Build:** `dotnet publish`
+
+:::info
+This is a pure .NET NativeAOT plugin that extracts Windows application icons using Shell32 APIs. It uses koffi FFI to call the native DLL from Node.js.
+:::
+
+### Build
+
+| Command | Script | Description |
+|---------|--------|-------------|
+| `npm run build` | `dotnet publish src/eIslandAppIconHelper.csproj -c Release -r win-x64` | Build NativeAOT DLL |
+| `npm run clean` | `dotnet clean src/eIslandAppIconHelper.csproj` | Remove build artifacts |
+| `npm run rebuild` | `npm run clean && npm run build` | Full clean build |
+
+### Test
+
+| Command | Script | Description |
+|---------|--------|-------------|
+| `npm test` | `vitest run` | All unit tests |
+| `npm run test:icon` | `vitest run test/icon.test.ts` | Icon function tests only |
+
+### Smoke
+
+| Command | Script | Description |
+|---------|--------|-------------|
+| `npm run smoke` | `node --experimental-strip-types test/icon.smoke.ts` | Full smoke — all icon functions |
+| `npm run smoke:process-name` | `node --experimental-strip-types test/icon.by-process-name.smoke.ts` | Process name lookup |
+| `npm run smoke:pid` | `node --experimental-strip-types test/icon.by-pid.smoke.ts` | PID lookup |
+| `npm run smoke:path` | `node --experimental-strip-types test/icon.by-path.smoke.ts` | Path lookup |
+| `npm run smoke:shortcut` | `node --experimental-strip-types test/icon.by-shortcut.smoke.ts` | Shortcut lookup |
+
+---
+
 ## Quick Reference
 
 ### All Build Commands
@@ -400,7 +437,8 @@ This is a pure .NET plugin that spawns a console EXE for WMI brightness operatio
 | WiFi Helper (DLL) | `cd plugins/eisland-windows-wifi-helper && npm run build:ctypes` |
 | WiFi Helper (all) | `cd plugins/eisland-windows-wifi-helper && npm run build:all` |
 | Brightness Helper | `cd plugins/eisland-windows-brightness-helper && npm run build` |
-| **All plugins** | `npm run plugins:build` (from root — builds all 9 plugins) |
+| Application Icon Helper | `cd plugins/eisland-windows-application-icon-helper && npm run build` |
+| **All plugins** | `npm run plugins:build` (from root — builds all 10 plugins) |
 
 ### All Test Commands
 
@@ -415,6 +453,7 @@ This is a pure .NET plugin that spawns a console EXE for WMI brightness operatio
 | Power Helper | `npm test` · `npm run test:query` · `npm run test:monitor` |
 | WiFi Helper | `npm test` · `npm run test:query` · `npm run test:monitor` |
 | Brightness Helper | `npm test` · `npm run test:query` · `npm run test:monitor` |
+| Application Icon Helper | `npm test` · `npm run test:icon` |
 
 ### All Smoke Commands
 
@@ -429,3 +468,4 @@ This is a pure .NET plugin that spawns a console EXE for WMI brightness operatio
 | Power Helper | `npm run smoke` · `npm run smoke:monitor` |
 | WiFi Helper | `npm run smoke` · `npm run smoke:monitor` |
 | Brightness Helper | `npm run smoke` · `npm run smoke:monitor` |
+| Application Icon Helper | `npm run smoke` · `npm run smoke:process-name` · `npm run smoke:pid` · `npm run smoke:path` · `npm run smoke:shortcut` |

--- a/web/eisland-web-docs/src/developer/environment-setup/plugin-setup.md
+++ b/web/eisland-web-docs/src/developer/environment-setup/plugin-setup.md
@@ -11,7 +11,7 @@ This guide covers the environment configuration for eIsland plugin development. 
 
 ## Overview
 
-eIsland uses nine native plugins to access Windows features that web technologies cannot provide:
+eIsland uses ten native plugins to access Windows features that web technologies cannot provide:
 
 | Plugin | Language | Windows Libraries | Purpose |
 |--------|----------|-------------------|---------|
@@ -24,9 +24,10 @@ eIsland uses nine native plugins to access Windows features that web technologie
 | **eisland-windows-power-helper** | C# (.NET) | — | Battery status and power event monitoring |
 | **eisland-windows-wifi-helper** | C# (.NET) | — | WiFi connection status and event monitoring |
 | **eisland-windows-brightness-helper** | C# (.NET) | — | Screen brightness query, control, and WMI event monitoring |
+| **eisland-windows-application-icon-helper** | C# (.NET) | Shell32 | Application icon extraction by process name, PID, path, or shortcut |
 
 :::important
-All plugins are compiled using **node-gyp**, which requires Visual Studio Build Tools 2022 as the native compiler. The `.npm install` process in the root project automatically triggers these builds.
+All plugins are compiled using **node-gyp** or **dotnet publish**, which requires Visual Studio Build Tools 2022 as the native compiler. The `npm run plugins:build` command in the root project automatically triggers these builds.
 :::
 
 ## Prerequisites


### PR DESCRIPTION
## Changes

- 

## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Document the new Windows Application Icon Helper plugin and integrate it into the shared plugin command and setup docs.

New Features:
- Add documentation section for the Windows Application Icon Helper plugin, including build, test, and smoke commands.

Enhancements:
- Update plugin command references to include the Application Icon Helper in global build/clean/test/smoke workflows and quick-reference tables.
- Revise environment setup docs to reflect ten native plugins and clarify that plugins are built via node-gyp or dotnet publish from the root build command.

Documentation:
- Extend developer plugin command docs with details and usage guidance for the Application Icon Helper plugin.
- Update environment setup and API plugin docs to describe the icon helper’s purpose, build behavior, and automatic inclusion in the root plugins build.