### PR TITLE
fix: restrict publish trigger to package.json changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-## Changes
-
-- 
-
 ## Verification
 
 - [ ] Verified locally (features / build / regression)

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'plugins/**'
+      - 'plugins/*/package.json'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -35,24 +35,46 @@ jobs:
           - eisland-windows-processes-attacker
           - eisland-windows-smtc-helper
           - eisland-windows-toast-listener
+          - eisland-windows-screenshot-helper
           - eisland-windows-wifi-helper
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: version
+        shell: bash
+        run: |
+          curr=$(node -p "require('./plugins/${{ matrix.plugin }}/package.json').version")
+          prev=$(git show HEAD~1:plugins/${{ matrix.plugin }}/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version" || echo "0.0.0")
+          echo "current=$curr" >> "$GITHUB_OUTPUT"
+          echo "previous=$prev" >> "$GITHUB_OUTPUT"
+          if [ "$curr" = "$prev" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($curr), skipping publish."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Version changed ($prev -> $curr), will publish."
+          fi
 
       - name: Setup Node.js
+        if: steps.version.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup .NET SDK
+        if: steps.version.outputs.skip != 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Install Visual Studio Build Tools
+        if: steps.version.outputs.skip != 'true'
         shell: pwsh
         run: |
           $installerPath = "${{ runner.temp }}\vs_buildtools.exe"
@@ -61,6 +83,7 @@ jobs:
           Remove-Item $installerPath
 
       - name: Publish to npm
+        if: steps.version.outputs.skip != 'true'
         working-directory: plugins/${{ matrix.plugin }}
         run: npm publish --access public ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
@@ -85,13 +108,33 @@ jobs:
           - eisland-windows-processes-attacker
           - eisland-windows-smtc-helper
           - eisland-windows-toast-listener
+          - eisland-windows-screenshot-helper
           - eisland-windows-wifi-helper
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: version
+        shell: bash
+        run: |
+          curr=$(node -p "require('./plugins/${{ matrix.plugin }}/package.json').version")
+          prev=$(git show HEAD~1:plugins/${{ matrix.plugin }}/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version" || echo "0.0.0")
+          echo "current=$curr" >> "$GITHUB_OUTPUT"
+          echo "previous=$prev" >> "$GITHUB_OUTPUT"
+          if [ "$curr" = "$prev" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($curr), skipping publish."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Version changed ($prev -> $curr), will publish."
+          fi
 
       - name: Setup Node.js
+        if: steps.version.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -99,11 +142,13 @@ jobs:
           scope: '@jntmtmtm'
 
       - name: Setup .NET SDK
+        if: steps.version.outputs.skip != 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Install Visual Studio Build Tools
+        if: steps.version.outputs.skip != 'true'
         shell: pwsh
         run: |
           $installerPath = "${{ runner.temp }}\vs_buildtools.exe"
@@ -112,6 +157,7 @@ jobs:
           Remove-Item $installerPath
 
       - name: Rewrite scope for GitHub Packages
+        if: steps.version.outputs.skip != 'true'
         shell: pwsh
         working-directory: plugins/${{ matrix.plugin }}
         run: |
@@ -120,6 +166,7 @@ jobs:
           $pkg | ConvertTo-Json -Depth 10 | Set-Content package.json -NoNewline
 
       - name: Publish to GitHub Packages
+        if: steps.version.outputs.skip != 'true'
         working-directory: plugins/${{ matrix.plugin }}
         run: npm publish --access public ${{ inputs.dry_run && '--dry-run' || '' }}
         env:


### PR DESCRIPTION
## Changes

- 

## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Restrict plugin publish workflows to package.json changes and add version-based gating so plugins are only published when their version changes.

Bug Fixes:
- Prevent unnecessary plugin publishes by only triggering workflows on package.json changes and skipping runs when versions are unchanged.

Enhancements:
- Include the eisland-windows-screenshot-helper plugin in both npm and GitHub Packages publish matrices.

CI:
- Update publish-plugins workflow triggers to watch only plugin package.json files and add a version comparison step that conditionally runs publish-related jobs.