### PR TITLE
feat: 选区截图支持可见窗口识别和吸附功能

### DIFF
--- a/plugins/eisland-windows-screenshot-helper/ffi-loader.js
+++ b/plugins/eisland-windows-screenshot-helper/ffi-loader.js
@@ -54,6 +54,7 @@ const sc = {
   sc_free_string: lib.func('void sc_free_string(void*)'),
   sc_get_last_error: lib.func('str sc_get_last_error()'),
   sc_capture_primary_display_png: lib.func('str sc_capture_primary_display_png()'),
+  sc_get_visible_windows: lib.func('str sc_get_visible_windows()'),
 };
 
 function getLastError() {
@@ -67,4 +68,10 @@ function callPng(fnName) {
   return { data, size: data.length, format: 'png' };
 }
 
-module.exports = { sc, callPng, getLastError, dllPath, TFM };
+function callJson(fnName) {
+  const raw = sc[fnName]();
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+module.exports = { sc, callPng, callJson, getLastError, dllPath, TFM };

--- a/plugins/eisland-windows-screenshot-helper/index.d.ts
+++ b/plugins/eisland-windows-screenshot-helper/index.d.ts
@@ -4,5 +4,16 @@ export interface ScreenshotResult {
   format: 'png';
 }
 
+export interface VisibleWindowBounds {
+  hwnd: string;
+  title: string;
+  processId: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export function capturePrimaryDisplayPng(): ScreenshotResult | null;
+export function getVisibleWindows(): VisibleWindowBounds[];
 export function getLastError(): string;

--- a/plugins/eisland-windows-screenshot-helper/index.js
+++ b/plugins/eisland-windows-screenshot-helper/index.js
@@ -22,13 +22,18 @@ if (process.platform !== 'win32') {
   throw new Error('@eisland/windows-screenshot-helper only supports Windows.');
 }
 
-const { callPng, getLastError } = require('./ffi-loader');
+const { callPng, callJson, getLastError } = require('./ffi-loader');
 
 function capturePrimaryDisplayPng() {
   return callPng('sc_capture_primary_display_png');
 }
 
+function getVisibleWindows() {
+  return callJson('sc_get_visible_windows') || [];
+}
+
 module.exports = {
   capturePrimaryDisplayPng,
+  getVisibleWindows,
   getLastError,
 };

--- a/plugins/eisland-windows-screenshot-helper/package-lock.json
+++ b/plugins/eisland-windows-screenshot-helper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eisland/windows-screenshot-helper",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eisland/windows-screenshot-helper",
-      "version": "26.0.0",
+      "version": "26.0.1",
       "cpu": [
         "x64"
       ],

--- a/plugins/eisland-windows-screenshot-helper/package.json
+++ b/plugins/eisland-windows-screenshot-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eisland/windows-screenshot-helper",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "High-performance Windows screen capture via Native AOT DLL and JS FFI.",
   "author": "JNTMTMTM",
   "license": "GPL-3.0",

--- a/plugins/eisland-windows-screenshot-helper/src/ScExports.cs
+++ b/plugins/eisland-windows-screenshot-helper/src/ScExports.cs
@@ -24,6 +24,10 @@ public static class ScExports
         {
             error = ScreenCapture.GetLastError();
         }
+        if (string.IsNullOrEmpty(error))
+        {
+            error = WindowBounds.GetLastError();
+        }
         return StringToCoTaskMem(error);
     }
 
@@ -35,6 +39,21 @@ public static class ScExports
         {
             var png = ScreenCapture.CapturePrimaryDisplayPng();
             return png.Length == 0 ? IntPtr.Zero : StringToCoTaskMem(Convert.ToBase64String(png));
+        }
+        catch (Exception ex)
+        {
+            _lastError = ex.ToString();
+            return IntPtr.Zero;
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "sc_get_visible_windows")]
+    public static IntPtr GetVisibleWindows()
+    {
+        _lastError = "";
+        try
+        {
+            return StringToCoTaskMem(WindowBounds.GetVisibleWindowsJson());
         }
         catch (Exception ex)
         {

--- a/plugins/eisland-windows-screenshot-helper/src/WindowBounds.cs
+++ b/plugins/eisland-windows-screenshot-helper/src/WindowBounds.cs
@@ -1,0 +1,182 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace eIslandScreenshotHelper;
+
+internal static class WindowBounds
+{
+    private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
+    private const int DWMWA_CLOAKED = 14;
+    private static string _lastError = "";
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    public static string GetLastError() => _lastError;
+
+    public static string GetVisibleWindowsJson()
+    {
+        _lastError = "";
+        var currentProcessId = Environment.ProcessId;
+        var windows = new List<WindowInfo>();
+
+        try
+        {
+            EnumWindows((hWnd, _) =>
+            {
+                if (!TryGetWindowInfo(hWnd, currentProcessId, out var info)) return true;
+                windows.Add(info);
+                return true;
+            }, IntPtr.Zero);
+        }
+        catch (Exception ex)
+        {
+            _lastError = ex.ToString();
+        }
+
+        return ToJson(windows);
+    }
+
+    private static bool TryGetWindowInfo(IntPtr hWnd, int currentProcessId, out WindowInfo info)
+    {
+        info = default;
+
+        if (hWnd == IntPtr.Zero || !IsWindowVisible(hWnd) || IsIconic(hWnd)) return false;
+        if (IsCloaked(hWnd)) return false;
+
+        _ = GetWindowThreadProcessId(hWnd, out var processId);
+        if ((int)processId == currentProcessId) return false;
+
+        if (!TryGetWindowRect(hWnd, out var rect)) return false;
+
+        var width = rect.Right - rect.Left;
+        var height = rect.Bottom - rect.Top;
+        if (width < 40 || height < 40) return false;
+
+        info = new WindowInfo(
+            Hwnd: hWnd.ToInt64().ToString("X"),
+            Title: GetWindowTitle(hWnd),
+            ProcessId: (int)processId,
+            X: rect.Left,
+            Y: rect.Top,
+            Width: width,
+            Height: height);
+        return true;
+    }
+
+    private static bool IsCloaked(IntPtr hWnd)
+    {
+        var result = DwmGetWindowAttribute(hWnd, DWMWA_CLOAKED, out int cloaked, Marshal.SizeOf<int>());
+        return result == 0 && cloaked != 0;
+    }
+
+    private static bool TryGetWindowRect(IntPtr hWnd, out RECT rect)
+    {
+        if (DwmGetWindowAttribute(hWnd, DWMWA_EXTENDED_FRAME_BOUNDS, out rect, Marshal.SizeOf<RECT>()) == 0)
+        {
+            return rect.Right > rect.Left && rect.Bottom > rect.Top;
+        }
+
+        return GetWindowRect(hWnd, out rect) && rect.Right > rect.Left && rect.Bottom > rect.Top;
+    }
+
+    private static string GetWindowTitle(IntPtr hWnd)
+    {
+        var length = GetWindowTextLengthW(hWnd);
+        if (length <= 0) return "";
+
+        var builder = new StringBuilder(length + 1);
+        var copied = GetWindowTextW(hWnd, builder, builder.Capacity);
+        return copied <= 0 ? "" : builder.ToString();
+    }
+
+    private static string ToJson(IReadOnlyList<WindowInfo> windows)
+    {
+        var builder = new StringBuilder(windows.Count * 128 + 2);
+        builder.Append('[');
+        for (var i = 0; i < windows.Count; i++)
+        {
+            if (i > 0) builder.Append(',');
+            var item = windows[i];
+            builder.Append('{')
+                .Append("\"hwnd\":\"").Append(EscapeJson(item.Hwnd)).Append("\",")
+                .Append("\"title\":\"").Append(EscapeJson(item.Title)).Append("\",")
+                .Append("\"processId\":").Append(item.ProcessId).Append(',')
+                .Append("\"x\":").Append(item.X).Append(',')
+                .Append("\"y\":").Append(item.Y).Append(',')
+                .Append("\"width\":").Append(item.Width).Append(',')
+                .Append("\"height\":").Append(item.Height)
+                .Append('}');
+        }
+        builder.Append(']');
+        return builder.ToString();
+    }
+
+    private static string EscapeJson(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return "";
+
+        var builder = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '\\': builder.Append("\\\\"); break;
+                case '"': builder.Append("\\\""); break;
+                case '\b': builder.Append("\\b"); break;
+                case '\f': builder.Append("\\f"); break;
+                case '\n': builder.Append("\\n"); break;
+                case '\r': builder.Append("\\r"); break;
+                case '\t': builder.Append("\\t"); break;
+                default:
+                    if (ch < ' ')
+                    {
+                        builder.Append("\\u").Append(((int)ch).ToString("x4"));
+                    }
+                    else
+                    {
+                        builder.Append(ch);
+                    }
+                    break;
+            }
+        }
+        return builder.ToString();
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextLengthW(IntPtr hWnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextW(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
+    private readonly record struct WindowInfo(string Hwnd, string Title, int ProcessId, int X, int Y, int Width, int Height);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+}

--- a/plugins/eisland-windows-screenshot-helper/test/screenshot.test.ts
+++ b/plugins/eisland-windows-screenshot-helper/test/screenshot.test.ts
@@ -43,6 +43,15 @@ interface ScreenshotResult {
 const screenshot = isWindows && hasNativeDll
   ? (require('../') as {
       capturePrimaryDisplayPng(): ScreenshotResult | null;
+      getVisibleWindows(): Array<{
+        hwnd: string;
+        title: string;
+        processId: number;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      }>;
       getLastError(): string;
     })
   : null;
@@ -63,6 +72,7 @@ describe.skipIf(!isWindows || !hasNativeDll)('@eisland/windows-screenshot-helper
 
   it('exports expected functions', () => {
     expect(typeof mod.capturePrimaryDisplayPng).toBe('function');
+    expect(typeof mod.getVisibleWindows).toBe('function');
     expect(typeof mod.getLastError).toBe('function');
   });
 
@@ -70,6 +80,20 @@ describe.skipIf(!isWindows || !hasNativeDll)('@eisland/windows-screenshot-helper
     const result = mod.capturePrimaryDisplayPng();
     expect(result).not.toBeNull();
     if (result) expectValidPng(result);
+  });
+
+  it('returns visible window bounds list', () => {
+    const windows = mod.getVisibleWindows();
+    expect(Array.isArray(windows)).toBe(true);
+    windows.forEach((item) => {
+      expect(typeof item.hwnd).toBe('string');
+      expect(typeof item.title).toBe('string');
+      expect(typeof item.processId).toBe('number');
+      expect(typeof item.x).toBe('number');
+      expect(typeof item.y).toBe('number');
+      expect(item.width).toBeGreaterThan(0);
+      expect(item.height).toBeGreaterThan(0);
+    });
   });
 
   it('does not throw on repeated capture', () => {

--- a/resources/capture.js
+++ b/resources/capture.js
@@ -77,6 +77,9 @@ const MAX_HISTORY = 10;
 const historyStack = [];
 let currentCaptureObjectUrl = '';
 let captureLanguage = 'zh-CN';
+let captureWindowRects = [];
+let hoverWindowRect = null;
+let pendingWindowClickRect = null;
 
 const CAPTURE_I18N = {
   'zh-CN': {
@@ -176,7 +179,17 @@ function drawMask() {
   maskCtx.clearRect(0, 0, W, H);
   if (state === STATE.IDLE) {
     maskCtx.fillStyle = 'rgba(0,0,0,0.35)';
-    maskCtx.fillRect(0, 0, W, H);
+    if (!hoverWindowRect) {
+      maskCtx.fillRect(0, 0, W, H);
+      return;
+    }
+    maskCtx.fillRect(0, 0, W, hoverWindowRect.y);
+    maskCtx.fillRect(0, hoverWindowRect.y + hoverWindowRect.height, W, H - hoverWindowRect.y - hoverWindowRect.height);
+    maskCtx.fillRect(0, hoverWindowRect.y, hoverWindowRect.x, hoverWindowRect.height);
+    maskCtx.fillRect(hoverWindowRect.x + hoverWindowRect.width, hoverWindowRect.y, W - hoverWindowRect.x - hoverWindowRect.width, hoverWindowRect.height);
+    maskCtx.strokeStyle = '#409cff';
+    maskCtx.lineWidth = 2;
+    maskCtx.strokeRect(hoverWindowRect.x, hoverWindowRect.y, hoverWindowRect.width, hoverWindowRect.height);
     return;
   }
 
@@ -225,6 +238,45 @@ function hitTestHandle(mx, my) {
 
 function isInsideSelection(mx, my) {
   return mx >= selX && mx <= selX + selW && my >= selY && my <= selY + selH;
+}
+
+function setVisibleWindowRects(windows, display) {
+  const displayBounds = display?.bounds || { x: 0, y: 0, width: window.innerWidth, height: window.innerHeight };
+  captureWindowRects = Array.isArray(windows)
+    ? windows.map((item) => {
+      const left = Math.max(item.x, displayBounds.x);
+      const top = Math.max(item.y, displayBounds.y);
+      const right = Math.min(item.x + item.width, displayBounds.x + displayBounds.width);
+      const bottom = Math.min(item.y + item.height, displayBounds.y + displayBounds.height);
+      return {
+        x: Math.max(0, Math.round(left - displayBounds.x)),
+        y: Math.max(0, Math.round(top - displayBounds.y)),
+        width: Math.round(right - left),
+        height: Math.round(bottom - top),
+        title: item.title || '',
+      };
+    }).filter((item) => item.width >= 40 && item.height >= 40)
+    : [];
+}
+
+function findWindowRectAt(mx, my) {
+  return captureWindowRects.find((item) => (
+    mx >= item.x && mx <= item.x + item.width && my >= item.y && my <= item.y + item.height
+  )) || null;
+}
+
+function selectWindowRect(rect) {
+  selX = rect.x;
+  selY = rect.y;
+  selW = rect.width;
+  selH = rect.height;
+  hoverWindowRect = null;
+  state = STATE.SELECTED;
+  historyStack.length = 0;
+  drawCtx.clearRect(0, 0, W, H);
+  showToolbar();
+  drawMask();
+  updateSizeInfo(selX, selY);
 }
 
 function clipToSelection(ctx) {
@@ -409,6 +461,7 @@ function drawRect(ctx, x1, y1, x2, y2) {
 }
 
 function finishSelection(mx, my) {
+  hoverWindowRect = null;
   selX = Math.min(startX, mx);
   selY = Math.min(startY, my);
   selW = Math.abs(mx - startX);
@@ -485,6 +538,7 @@ function releaseCaptureResources() {
 ipcRenderer.on('capture-image', (_e, data) => {
   scaleFactor = data.scaleFactor || 1;
   setCaptureSource(data.captureSource);
+  setVisibleWindowRects(data.visibleWindows, data.display);
 
   if (currentCaptureObjectUrl) {
     URL.revokeObjectURL(currentCaptureObjectUrl);
@@ -528,10 +582,12 @@ tempCanvas.addEventListener('mousedown', (e) => {
   const mx = e.clientX;
   const my = e.clientY;
 
-  if (state === STATE.IDLE || state === STATE.DRAWING) {
+  if (state === STATE.IDLE) {
+    pendingWindowClickRect = hoverWindowRect;
     state = STATE.DRAWING;
     startX = mx;
     startY = my;
+    hoverWindowRect = null;
     hideToolbar();
     drawMask();
     return;
@@ -587,6 +643,16 @@ tempCanvas.addEventListener('mousedown', (e) => {
 tempCanvas.addEventListener('mousemove', (e) => {
   const mx = e.clientX;
   const my = e.clientY;
+
+  if (state === STATE.IDLE) {
+    const nextHoverWindow = findWindowRectAt(mx, my);
+    if (nextHoverWindow !== hoverWindowRect) {
+      hoverWindowRect = nextHoverWindow;
+      drawMask();
+    }
+    document.body.style.cursor = 'crosshair';
+    return;
+  }
 
   if (state === STATE.DRAWING) {
     selX = Math.min(startX, mx);
@@ -677,6 +743,13 @@ tempCanvas.addEventListener('mouseup', (e) => {
   const my = e.clientY;
 
   if (state === STATE.DRAWING) {
+    const moved = Math.abs(mx - startX) >= 3 || Math.abs(my - startY) >= 3;
+    if (!moved && pendingWindowClickRect) {
+      selectWindowRect(pendingWindowClickRect);
+      pendingWindowClickRect = null;
+      return;
+    }
+    pendingWindowClickRect = null;
     finishSelection(mx, my);
     return;
   }

--- a/src/main/window/captureWindow.ts
+++ b/src/main/window/captureWindow.ts
@@ -29,7 +29,7 @@ import { app, BrowserWindow, desktopCapturer, screen } from 'electron';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { is } from '@electron-toolkit/utils';
-import { capturePrimaryDisplayPng } from './screenshotHelper';
+import { capturePrimaryDisplayPng, getVisibleWindows } from './screenshotHelper';
 
 interface CreateCaptureWindowServiceOptions {
   getMainWindow: () => BrowserWindow | null;
@@ -105,6 +105,7 @@ export function createCaptureWindowService(options: CreateCaptureWindowServiceOp
       await waitForMainWindowHidden();
 
       const nativeScreenshot = capturePrimaryDisplayPng();
+      const visibleWindows = getVisibleWindows();
       const sourcesPromise = nativeScreenshot
         ? null
         : desktopCapturer.getSources({
@@ -173,6 +174,7 @@ export function createCaptureWindowService(options: CreateCaptureWindowServiceOp
           display: primaryDisplay,
           scaleFactor: sf,
           captureSource: nativeScreenshot ? 'plugin' : 'js',
+          visibleWindows,
         });
         captureWindow.setIgnoreMouseEvents(false);
         captureWindow.setOpacity(1);

--- a/src/main/window/screenshotHelper.ts
+++ b/src/main/window/screenshotHelper.ts
@@ -32,8 +32,19 @@ interface ScreenshotResult {
   format: 'png';
 }
 
+export interface VisibleWindowBounds {
+  hwnd: string;
+  title: string;
+  processId: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 interface WindowsScreenshotHelper {
   capturePrimaryDisplayPng: () => ScreenshotResult | null;
+  getVisibleWindows?: () => VisibleWindowBounds[];
   getLastError?: () => string;
 }
 
@@ -90,5 +101,18 @@ export function capturePrimaryDisplayPng(): Buffer | null {
   } catch (err) {
     console.warn('[ScreenshotHelper] capture error, fallback to desktopCapturer:', err);
     return null;
+  }
+}
+
+export function getVisibleWindows(): VisibleWindowBounds[] {
+  const helper = loadWindowsScreenshotHelper();
+  if (!helper?.getVisibleWindows) return [];
+
+  try {
+    const windows = helper.getVisibleWindows();
+    return Array.isArray(windows) ? windows : [];
+  } catch (err) {
+    console.warn('[ScreenshotHelper] window bounds unavailable:', err);
+    return [];
   }
 }

--- a/src/main/window/screenshotHelper.ts
+++ b/src/main/window/screenshotHelper.ts
@@ -104,6 +104,11 @@ export function capturePrimaryDisplayPng(): Buffer | null {
   }
 }
 
+/**
+ * 获取所有可见窗口的位置和尺寸信息
+ * @description 枚举桌面上所有可见的顶层窗口，返回其边界矩形和元数据，用于截图选区的窗口识别
+ * @returns 可见窗口边界数组，插件不可用时返回空数组
+ */
 export function getVisibleWindows(): VisibleWindowBounds[] {
   const helper = loadWindowsScreenshotHelper();
   if (!helper?.getVisibleWindows) return [];

--- a/web/eisland-web-docs/src/.vuepress/components/SidebarBadges.vue
+++ b/web/eisland-web-docs/src/.vuepress/components/SidebarBadges.vue
@@ -82,6 +82,7 @@ const BADGE_MAP: Record<string, string> = {
   IconResult: 'interface',
   // Screenshot Helper
   ScreenshotResult: 'interface',
+  VisibleWindowBounds: 'interface',
 }
 
 // ── badge label text ─────────────────────────────────────────────

--- a/web/eisland-web-docs/src/.vuepress/sidebar.ts
+++ b/web/eisland-web-docs/src/.vuepress/sidebar.ts
@@ -105,7 +105,9 @@ export default sidebar({
       collapsible: true,
       children: [
         "display-graphics/screenshot-helper/screenshot-result.md",
+        "display-graphics/screenshot-helper/visible-window-bounds.md",
         "display-graphics/screenshot-helper/capture-primary-display-png.md",
+        "display-graphics/screenshot-helper/get-visible-windows.md",
         "display-graphics/screenshot-helper/get-last-error.md",
       ],
     },

--- a/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper.md
+++ b/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper.md
@@ -9,7 +9,7 @@ icon: camera
 `@eisland/windows-screenshot-helper` · v26.0.0
 
 :::info
-Capture the primary display as PNG via .NET Native AOT DLL (koffi FFI). This plugin provides a lightweight, high-performance screen capture function using Windows GDI APIs (`BitBlt` with `SRCCOPY | CAPTUREBLT`).
+Capture the primary display as PNG and enumerate visible windows via .NET Native AOT DLL (koffi FFI). This plugin provides lightweight, high-performance screen capture using Windows GDI APIs (`BitBlt` with `SRCCOPY | CAPTUREBLT`) and window enumeration using `EnumWindows` with DWM extended frame bounds.
 :::
 
 ## Interfaces
@@ -17,16 +17,18 @@ Capture the primary display as PNG via .NET Native AOT DLL (koffi FFI). This plu
 | Interface | Description |
 |-----------|-------------|
 | [ScreenshotResult](screenshot-helper/screenshot-result.md) | Screenshot data structure |
+| [VisibleWindowBounds](screenshot-helper/visible-window-bounds.md) | Visible window bounding rectangle and metadata |
 
 ## Functions
 
 | Function | Description |
 |----------|-------------|
 | [capturePrimaryDisplayPng](screenshot-helper/capture-primary-display-png.md) | Capture the primary display as PNG |
+| [getVisibleWindows](screenshot-helper/get-visible-windows.md) | Enumerate visible windows and return their bounds |
 | [getLastError](screenshot-helper/get-last-error.md) | Get the last error message from the DLL |
 
 :::tip
-`capturePrimaryDisplayPng` returns `ScreenshotResult | null`. The result contains a PNG buffer with the full primary display content. Returns `null` when the capture fails — use `getLastError` to retrieve the error message. The DLL reports specific GDI failure reasons (e.g., `GetDC failed`, `BitBlt failed`, `invalid primary display dimensions`) through `getLastError`, not just exceptions.
+`capturePrimaryDisplayPng` returns `ScreenshotResult | null`. The result contains a PNG buffer with the full primary display content. Returns `null` when the capture fails — use `getLastError` to retrieve the error message. `getVisibleWindows` returns `VisibleWindowBounds[]` with the position and size of every visible application window, enabling window-aware screenshot selection.
 :::
 
 ## Build
@@ -65,10 +67,11 @@ Smoke tests require manual execution and display results in the console. Unit te
 | `index.d.ts` | TypeScript type declarations |
 | `ffi-loader.js` | koffi FFI bridge to Native AOT DLL |
 | `src/ScreenCapture.cs` | Core screen capture logic (Win32 GDI APIs) |
+| `src/WindowBounds.cs` | Visible window enumeration (EnumWindows + DWM) |
 | `src/ScExports.cs` | C ABI exports for FFI |
 | `src/Program.cs` | Native AOT library entry point |
 | `src/eIslandScreenshotHelper.csproj` | .NET 10 Native AOT project |
 
 :::important
-The DLL uses Win32 GDI `BitBlt` with `SRCCOPY | CAPTUREBLT` flags to capture the primary display. The result is returned as a base64-encoded PNG string through the FFI boundary, then decoded into a Node.js `Buffer`.
+The DLL uses Win32 GDI `BitBlt` with `SRCCOPY | CAPTUREBLT` flags to capture the primary display. The result is returned as a base64-encoded PNG string through the FFI boundary, then decoded into a Node.js `Buffer`. Window enumeration uses `EnumWindows` with `DwmGetWindowAttribute` for accurate bounds and cloaking detection.
 :::

--- a/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/README.md
+++ b/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/README.md
@@ -9,7 +9,7 @@ icon: camera
 `@eisland/windows-screenshot-helper` · v26.0.0
 
 :::info
-Capture the primary display as PNG via .NET Native AOT DLL (koffi FFI).
+Capture the primary display as PNG and enumerate visible windows via .NET Native AOT DLL (koffi FFI).
 :::
 
 ## API Reference
@@ -17,7 +17,9 @@ Capture the primary display as PNG via .NET Native AOT DLL (koffi FFI).
 | Type | Name | Description |
 |------|------|-------------|
 | Interface | [ScreenshotResult](screenshot-result.md) | Screenshot data structure |
+| Interface | [VisibleWindowBounds](visible-window-bounds.md) | Visible window bounding rectangle and metadata |
 | Function | [capturePrimaryDisplayPng](capture-primary-display-png.md) | Capture the primary display as PNG |
+| Function | [getVisibleWindows](get-visible-windows.md) | Enumerate visible windows and return their bounds |
 | Function | [getLastError](get-last-error.md) | Get the last error message from the DLL |
 
 :::tip

--- a/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/get-visible-windows.md
+++ b/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/get-visible-windows.md
@@ -1,0 +1,113 @@
+---
+watermark: true
+title: getVisibleWindows
+icon: fa6-solid:code
+---
+
+# getVisibleWindows
+
+:::info
+Enumerates all visible top-level windows and returns their bounding rectangles. This function calls into the Native AOT DLL which uses Win32 APIs (`EnumWindows`, `DwmGetWindowAttribute`, `GetWindowRect`) to collect window positions. Returns an array of [VisibleWindowBounds](visible-window-bounds.md) objects, or an empty array if no windows are found or the DLL is unavailable.
+:::
+
+## Signature
+
+```typescript
+function getVisibleWindows(): VisibleWindowBounds[];
+```
+
+## Parameters
+
+This function takes no parameters.
+
+## Usage
+
+The `getVisibleWindows` function provides window geometry data for the capture overlay. It enables window recognition during screenshot selection — the overlay highlights windows on hover and allows single-click selection.
+
+Typical workflow:
+
+1. Call `getVisibleWindows()` before or during the capture overlay display.
+2. Pass the returned array to the capture window along with the screenshot image.
+3. The overlay maps window bounds to display coordinates and uses them for hit-testing.
+4. When the user hovers over a window region, the overlay draws a highlight border.
+5. A single click selects the entire window region for capture.
+
+:::note
+The function filters out minimized windows, cloaked windows (hidden by the DWM compositor), windows smaller than 40x40 pixels, and the caller's own process windows. Only visible, meaningful application windows are returned.
+:::
+
+:::tip
+Call `getVisibleWindows` after the main window is hidden but before sending the capture image to the overlay. This ensures the window list reflects the desktop state at capture time without the eIsland main window appearing in the results.
+:::
+
+## Return Value
+
+| Type | Description |
+|------|-------------|
+| `VisibleWindowBounds[]` | Array of visible window bounds, or empty array on failure |
+
+Returns an array of [VisibleWindowBounds](visible-window-bounds.md) objects. Each object contains the window handle, title, process ID, and bounding rectangle. Returns an empty array `[]` if the DLL is unavailable, no visible windows are found, or an error occurs.
+
+:::warning
+The returned bounds are in virtual screen coordinates. On multi-monitor setups, coordinates may be negative or extend beyond a single display's resolution. Use the `display.bounds` from Electron's `screen.getPrimaryDisplay()` to map coordinates to the capture overlay's coordinate space.
+:::
+
+## Example
+
+::: code-tabs
+
+@tab TypeScript
+
+```ts
+import { getVisibleWindows, VisibleWindowBounds } from '@eisland/windows-screenshot-helper';
+
+const windows: VisibleWindowBounds[] = getVisibleWindows();
+
+if (windows.length > 0) {
+  console.log(`Found ${windows.length} visible windows`);
+  windows.forEach((w) => {
+    console.log(`  [${w.hwnd}] "${w.title}" — ${w.width}x${w.height} at (${w.x},${w.y})`);
+  });
+} else {
+  console.log('No visible windows found');
+}
+```
+
+@tab JavaScript
+
+```js
+const { getVisibleWindows } = require('@eisland/windows-screenshot-helper');
+
+const windows = getVisibleWindows();
+
+if (windows.length > 0) {
+  console.log(`Found ${windows.length} visible windows`);
+  windows.forEach((w) => {
+    console.log(`  [${w.hwnd}] "${w.title}" — ${w.width}x${w.height} at (${w.x},${w.y})`);
+  });
+} else {
+  console.log('No visible windows found');
+}
+```
+
+:::
+
+## Notes
+
+:::note
+The function calls `sc_get_visible_windows` via koffi FFI. The DLL enumerates windows using `EnumWindows`, checks visibility and cloaking state via `DwmGetWindowAttribute`, and returns a JSON array. The FFI loader parses the JSON into a JavaScript array of objects.
+:::
+
+:::tip
+The function returns an empty array (not `null`) on failure, so it is safe to call without null-checking. However, always verify `windows.length > 0` before using the results.
+:::
+
+:::important
+This plugin is Windows-only (`os: ['win32']`). On non-Windows platforms, `getVisibleWindows` is not available. The main process wrapper in `screenshotHelper.ts` handles this gracefully by returning an empty array.
+:::
+
+## Danger Avoidance
+
+:::danger
+Do not call `getVisibleWindows` in a tight loop. Each call enumerates all top-level windows via `EnumWindows` and queries DWM attributes for each one. Rapid successive calls can cause noticeable CPU overhead. Cache the results and refresh only when the desktop state changes (e.g., before showing the capture overlay).
+:::

--- a/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/visible-window-bounds.md
+++ b/web/eisland-web-docs/src/api-plugins/display-graphics/screenshot-helper/visible-window-bounds.md
@@ -1,0 +1,109 @@
+---
+watermark: true
+title: VisibleWindowBounds
+icon: fa6-solid:table
+---
+
+# VisibleWindowBounds
+
+:::info
+Represents the bounding rectangle and metadata of a visible top-level window on the desktop. This interface is returned as elements of the array from the `getVisibleWindows` function. Each entry describes one window's position, size, and identity — used by the capture overlay to highlight and select windows for screenshot capture.
+:::
+
+## Interface Definition
+
+```typescript
+interface VisibleWindowBounds {
+  hwnd: string;
+  title: string;
+  processId: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+```
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hwnd` | `string` | Window handle as a hexadecimal string (e.g., `"1A2B3C"`) |
+| `title` | `string` | Window title text, or empty string if untitled |
+| `processId` | `number` | Process ID that owns the window |
+| `x` | `number` | X coordinate of the window's left edge in screen pixels |
+| `y` | `number` | Y coordinate of the window's top edge in screen pixels |
+| `width` | `number` | Window width in pixels (excludes invisible borders when DWM extended frame bounds are available) |
+| `height` | `number` | Window height in pixels |
+
+## Usage
+
+The `VisibleWindowBounds` interface is returned by the [getVisibleWindows](get-visible-windows.md) function. Each entry represents one visible, non-minimized, non-cloaked top-level window.
+
+The capture overlay uses these bounds to highlight windows when the mouse hovers over them, enabling single-click window selection for screenshots.
+
+:::note
+The `hwnd` value is a hexadecimal string representation of the Win32 `HWND`. It is not a numeric value — compare it as a string, not a number.
+:::
+
+:::tip
+The `x`, `y`, `width`, and `height` values use DWM extended frame bounds when available, which excludes the invisible resize border that Windows adds around windows. This produces tighter, more accurate capture regions than raw `GetWindowRect`.
+:::
+
+## Example
+
+::: code-tabs
+
+@tab TypeScript
+
+```ts
+import { getVisibleWindows, VisibleWindowBounds } from '@eisland/windows-screenshot-helper';
+
+const windows: VisibleWindowBounds[] = getVisibleWindows();
+
+for (const win of windows) {
+  console.log(`[${win.hwnd}] "${win.title}" at (${win.x},${win.y}) ${win.width}x${win.height} (PID ${win.processId})`);
+}
+
+// Find a specific window by title
+const browser = windows.find((w) => w.title.includes('Chrome'));
+if (browser) {
+  console.log(`Found browser at ${browser.x},${browser.y}`);
+}
+```
+
+@tab JavaScript
+
+```js
+const { getVisibleWindows } = require('@eisland/windows-screenshot-helper');
+
+const windows = getVisibleWindows();
+
+for (const win of windows) {
+  console.log(`[${win.hwnd}] "${win.title}" at (${win.x},${win.y}) ${win.width}x${win.height} (PID ${win.processId})`);
+}
+
+// Find a specific window by title
+const browser = windows.find((w) => w.title.includes('Chrome'));
+if (browser) {
+  console.log(`Found browser at ${browser.x},${browser.y}`);
+}
+```
+
+:::
+
+## Notes
+
+:::important
+Windows smaller than 40x40 pixels are filtered out. Cloaked windows (hidden by the compositor, such as UWP suspended apps) and minimized windows are also excluded.
+:::
+
+:::warning
+The bounds represent the window's position on the virtual screen. On multi-monitor setups, coordinates can be negative. The caller is responsible for mapping these coordinates to the correct display when performing region-based operations.
+:::
+
+## Danger Avoidance
+
+:::danger
+Do not assume the `title` property is unique or non-empty. Many windows share the same title, and some windows (e.g., tooltip hosts) return an empty string. Always use `hwnd` as the unique identifier when tracking specific windows.
+:::


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Introduce visible window enumeration in the Windows screenshot helper and wire it into the capture overlay to support window recognition, hover highlighting, and snapping during screenshot selection, along with corresponding tests and documentation updates.

New Features:
- Add window-aware hover highlighting and single-click snapping to visible application windows in the screenshot selection overlay.
- Expose a getVisibleWindows API in the Windows screenshot helper plugin and main process to return bounds and metadata of visible top-level windows.

Enhancements:
- Integrate visible window bounds into the capture flow so the overlay receives both the screenshot image and window rectangles for hit-testing.
- Improve error reporting in the native DLL by aggregating last error messages from both screen capture and window enumeration components.

Documentation:
- Extend screenshot helper plugin documentation with getVisibleWindows, VisibleWindowBounds, usage guidelines, and sidebar/navigation entries.

Tests:
- Add unit tests to validate the presence and shape of the new getVisibleWindows function and its returned window metadata.

Chores:
- Bump @eisland/windows-screenshot-helper package version from 26.0.0 to 26.0.1.