### PR TITLE
feat: 添加 OAuth 接口管理功能和第三方服务列表

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3198,6 +3198,14 @@
           "username": "Username",
           "providerUserId": "Third-party User ID",
           "boundAt": "Bound at"
+        },
+        "actions": {
+          "unbind": "Unbind",
+          "unbinding": "Unbinding…"
+        },
+        "feedback": {
+          "unbindSuccess": "Unbound successfully",
+          "unbindFailed": "Failed to unbind"
         }
       },
       "recharge": {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3173,7 +3173,8 @@
         "proDesc": "View Pro plan benefits plus current subscription pricing",
         "rechargeDesc": "Top up your balance for AI assistant conversations",
         "ordersDesc": "Check order status, continue payment, or close pending orders",
-        "logoutDesc": "Sign out or delete your account"
+        "logoutDesc": "Sign out or delete your account",
+        "oauthDesc": "View linked third-party login accounts"
       },
       "pages": {
         "info": "Profile",
@@ -3195,7 +3196,7 @@
         },
         "fields": {
           "username": "Username",
-          "email": "Email",
+          "providerUserId": "Third-party User ID",
           "boundAt": "Bound at"
         }
       },

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3186,6 +3186,19 @@
         "oauth": "Third-party App Binding",
         "switchTo": "Switch to {{label}}"
       },
+      "oauth": {
+        "subtitle": "Manage linked third-party login accounts",
+        "loading": "Loading…",
+        "empty": "No third-party bindings",
+        "provider": {
+          "wechat": "WeChat"
+        },
+        "fields": {
+          "username": "Username",
+          "email": "Email",
+          "boundAt": "Bound at"
+        }
+      },
       "recharge": {
         "title": "Recharge Balance",
         "subtitle": "Top up your balance for AI assistant conversations",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3183,6 +3183,7 @@
         "recharge": "Recharge",
         "orders": "My Orders",
         "account": "Account",
+        "oauth": "Third-party App Binding",
         "switchTo": "Switch to {{label}}"
       },
       "recharge": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3186,6 +3186,19 @@
         "oauth": "第三方应用绑定",
         "switchTo": "切换到{{label}}"
       },
+      "oauth": {
+        "subtitle": "管理已绑定的第三方登录账号",
+        "loading": "加载中…",
+        "empty": "暂无第三方绑定",
+        "provider": {
+          "wechat": "微信"
+        },
+        "fields": {
+          "username": "用户名",
+          "email": "邮箱",
+          "boundAt": "绑定时间"
+        }
+      },
       "recharge": {
         "title": "余额充值",
         "subtitle": "充值后可用于 AI 助手对话消耗",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3183,6 +3183,7 @@
         "recharge": "余额充值",
         "orders": "我的订单",
         "account": "关于账户",
+        "oauth": "第三方应用绑定",
         "switchTo": "切换到{{label}}"
       },
       "recharge": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3198,6 +3198,14 @@
           "username": "用户名",
           "providerUserId": "第三方用户ID",
           "boundAt": "绑定时间"
+        },
+        "actions": {
+          "unbind": "解除绑定",
+          "unbinding": "解除中…"
+        },
+        "feedback": {
+          "unbindSuccess": "已解除绑定",
+          "unbindFailed": "解除绑定失败"
         }
       },
       "recharge": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3173,7 +3173,8 @@
         "proDesc": "查看 Pro 计划权益及当前订阅价格",
         "rechargeDesc": "为 AI 助手对话余额充值",
         "ordersDesc": "查看订单状态、继续支付或主动关闭待支付订单",
-        "logoutDesc": "退出当前账号或注销"
+        "logoutDesc": "退出当前账号或注销",
+        "oauthDesc": "查看已绑定的第三方登录账号"
       },
       "pages": {
         "info": "用户信息",
@@ -3195,7 +3196,7 @@
         },
         "fields": {
           "username": "用户名",
-          "email": "邮箱",
+          "providerUserId": "第三方用户ID",
           "boundAt": "绑定时间"
         }
       },

--- a/src/renderer/api/user/userAccountApi.oauth.ts
+++ b/src/renderer/api/user/userAccountApi.oauth.ts
@@ -198,3 +198,17 @@ export function unbindOAuth(token: string, bindingId: number): Promise<UserAccou
     auth: token,
   });
 }
+
+/** OAuth 登录方式项 */
+export interface OAuthProviderItem {
+  provider: string;
+  displayName: string;
+}
+
+/**
+ * 获取可用的 OAuth 登录方式列表。
+ * @returns 可用的提供商列表。
+ */
+export function fetchOAuthProviders(): Promise<UserAccountResult<OAuthProviderItem[]>> {
+  return request<OAuthProviderItem[]>('/auth/oauth/providers');
+}

--- a/src/renderer/api/user/userAccountApi.oauth.ts
+++ b/src/renderer/api/user/userAccountApi.oauth.ts
@@ -185,3 +185,16 @@ export function fetchOAuthBindings(token: string): Promise<UserAccountResult<OAu
     auth: token,
   });
 }
+
+/**
+ * 解除当前用户的指定第三方应用绑定。
+ * @param token - 用户 token。
+ * @param bindingId - 绑定记录 ID。
+ * @returns 操作结果。
+ */
+export function unbindOAuth(token: string, bindingId: number): Promise<UserAccountResult<unknown>> {
+  return request(`/v1/user/oauth-bindings/${bindingId}`, {
+    method: 'DELETE',
+    auth: token,
+  });
+}

--- a/src/renderer/api/user/userAccountApi.oauth.ts
+++ b/src/renderer/api/user/userAccountApi.oauth.ts
@@ -24,8 +24,18 @@
  * @author 鸡哥
  */
 
-import { githubRequest } from './userAccountApi.client';
+import { githubRequest, request } from './userAccountApi.client';
 import type { UserAccountLoginData, UserAccountResult } from './userAccountApi.types';
+
+/** OAuth 绑定记录 */
+export interface OAuthBindingItem {
+  id: number;
+  provider: string;
+  providerUserId: string;
+  providerUsername: string | null;
+  providerEmail: string | null;
+  createdAt: string | null;
+}
 
 /** OAuth 回调状态 */
 export type OAuthCallbackStatus = 'LOGIN' | 'SET_PASSWORD' | 'BIND_OAUTH' | 'ERROR';
@@ -161,5 +171,17 @@ export function oauthBindAccount(
     method: 'POST',
     body: { tempToken, password },
     timeoutMs: 15000,
+  });
+}
+
+/**
+ * 查询当前用户的第三方应用绑定信息。
+ * @param token - 用户 token。
+ * @returns 绑定列表。
+ */
+export function fetchOAuthBindings(token: string): Promise<UserAccountResult<OAuthBindingItem[]>> {
+  return request<OAuthBindingItem[]>('/v1/user/oauth-bindings', {
+    method: 'GET',
+    auth: token,
   });
 }

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -38,5 +38,5 @@ export * from './userAccountApi.profile';
 export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
-export { fetchOAuthBindings, unbindOAuth } from './userAccountApi.oauth';
-export type { OAuthBindingItem } from './userAccountApi.oauth';
+export { fetchOAuthBindings, unbindOAuth, fetchOAuthProviders } from './userAccountApi.oauth';
+export type { OAuthBindingItem, OAuthProviderItem } from './userAccountApi.oauth';

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -38,5 +38,5 @@ export * from './userAccountApi.profile';
 export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
-export { fetchOAuthBindings } from './userAccountApi.oauth';
+export { fetchOAuthBindings, unbindOAuth } from './userAccountApi.oauth';
 export type { OAuthBindingItem } from './userAccountApi.oauth';

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -38,3 +38,5 @@ export * from './userAccountApi.profile';
 export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
+export { fetchOAuthBindings } from './userAccountApi.oauth';
+export type { OAuthBindingItem } from './userAccountApi.oauth';

--- a/src/renderer/components/states/login/LoginContent.tsx
+++ b/src/renderer/components/states/login/LoginContent.tsx
@@ -62,6 +62,7 @@ export function LoginContent(): ReactElement {
       handleMicrosoftLogin={login.handleMicrosoftLogin}
       wechatLoading={login.wechatLoading}
       handleWechatLogin={login.handleWechatLogin}
+      disabledProviders={login.disabledProviders}
       t={login.t}
     />
   );

--- a/src/renderer/components/states/login/components/LoginForm.tsx
+++ b/src/renderer/components/states/login/components/LoginForm.tsx
@@ -211,11 +211,9 @@ export function LoginForm(props: LoginFormProps): ReactElement {
             disabled={oauthBusy || microsoftDisabled}
           >
             <img className="auth-oauth-icon" src={SvgIcon.MICROSOFT} alt="" width={18} height={18} />
-            {microsoftDisabled
-              ? t('oauth.microsoft.disabled', { defaultValue: 'Microsoft 暂不可用' })
-              : microsoftLoading
-                ? t('oauth.microsoft.loading', { defaultValue: '连接中…' })
-                : t('oauth.microsoft.login', { defaultValue: 'Microsoft' })}
+            {microsoftLoading
+              ? t('oauth.microsoft.loading', { defaultValue: '连接中…' })
+              : t('oauth.microsoft.login', { defaultValue: 'Microsoft' })}
           </button>
           <button
             type="button"
@@ -224,11 +222,9 @@ export function LoginForm(props: LoginFormProps): ReactElement {
             disabled={oauthBusy || wechatDisabled}
           >
             <img className="auth-oauth-icon" src={SvgIcon.WECHAT} alt="" width={18} height={18} />
-            {wechatDisabled
-              ? t('oauth.wechat.disabled', { defaultValue: '微信登录暂不可用' })
-              : wechatLoading
-                ? t('oauth.wechat.loading', { defaultValue: '连接中…' })
-                : t('oauth.wechat.login', { defaultValue: 'WeChat' })}
+            {wechatLoading
+              ? t('oauth.wechat.loading', { defaultValue: '连接中…' })
+              : t('oauth.wechat.login', { defaultValue: 'WeChat' })}
           </button>
         </div>
       </div>

--- a/src/renderer/components/states/login/components/LoginForm.tsx
+++ b/src/renderer/components/states/login/components/LoginForm.tsx
@@ -58,10 +58,14 @@ export function LoginForm(props: LoginFormProps): ReactElement {
     handleMicrosoftLogin,
     wechatLoading,
     handleWechatLogin,
+    disabledProviders,
     t,
   } = props;
 
   const oauthBusy = submitting || githubLoading || microsoftLoading || wechatLoading;
+  const githubDisabled = disabledProviders.has('github');
+  const microsoftDisabled = disabledProviders.has('microsoft');
+  const wechatDisabled = disabledProviders.has('wechat');
 
   return (
     <div className="auth-state-content" onClick={(e) => e.stopPropagation()}>
@@ -193,7 +197,7 @@ export function LoginForm(props: LoginFormProps): ReactElement {
             type="button"
             className="auth-oauth-btn auth-oauth-btn--github"
             onClick={() => void handleGitHubLogin()}
-            disabled={oauthBusy}
+            disabled={oauthBusy || githubDisabled}
           >
             <img className="auth-oauth-icon" src={SvgIcon.GITHUB} alt="" width={18} height={18} />
             {githubLoading
@@ -204,23 +208,27 @@ export function LoginForm(props: LoginFormProps): ReactElement {
             type="button"
             className="auth-oauth-btn auth-oauth-btn--microsoft"
             onClick={() => void handleMicrosoftLogin()}
-            disabled={oauthBusy}
+            disabled={oauthBusy || microsoftDisabled}
           >
             <img className="auth-oauth-icon" src={SvgIcon.MICROSOFT} alt="" width={18} height={18} />
-            {microsoftLoading
-              ? t('oauth.microsoft.loading', { defaultValue: '连接中…' })
-              : t('oauth.microsoft.login', { defaultValue: 'Microsoft' })}
+            {microsoftDisabled
+              ? t('oauth.microsoft.disabled', { defaultValue: 'Microsoft 暂不可用' })
+              : microsoftLoading
+                ? t('oauth.microsoft.loading', { defaultValue: '连接中…' })
+                : t('oauth.microsoft.login', { defaultValue: 'Microsoft' })}
           </button>
           <button
             type="button"
             className="auth-oauth-btn auth-oauth-btn--wechat"
             onClick={() => void handleWechatLogin()}
-            disabled={oauthBusy}
+            disabled={oauthBusy || wechatDisabled}
           >
             <img className="auth-oauth-icon" src={SvgIcon.WECHAT} alt="" width={18} height={18} />
-            {wechatLoading
-              ? t('oauth.wechat.loading', { defaultValue: '连接中…' })
-              : t('oauth.wechat.login', { defaultValue: 'WeChat' })}
+            {wechatDisabled
+              ? t('oauth.wechat.disabled', { defaultValue: '微信登录暂不可用' })
+              : wechatLoading
+                ? t('oauth.wechat.loading', { defaultValue: '连接中…' })
+                : t('oauth.wechat.login', { defaultValue: 'WeChat' })}
           </button>
         </div>
       </div>

--- a/src/renderer/components/states/login/hooks/useLogin.ts
+++ b/src/renderer/components/states/login/hooks/useLogin.ts
@@ -27,7 +27,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useIslandStore from '../../../../store/slices';
-import { loginUserByAccount, loginUserByEmailWithCode, sendUserEmailCode } from '../../../../api/user/userAccountApi';
+import { loginUserByAccount, loginUserByEmailWithCode, sendUserEmailCode, fetchOAuthProviders } from '../../../../api/user/userAccountApi';
 import { updateSessionToken } from '../../../../utils/authSession';
 import { runSliderCaptcha } from '../../../../utils/sliderCaptcha';
 import { openGitHubOAuth, openMicrosoftOAuth, openWechatOAuth } from '../../../../utils/oauthWindow';
@@ -201,6 +201,21 @@ export function useLogin() {
   const [githubLoading, setGithubLoading] = useState(false);
   const [microsoftLoading, setMicrosoftLoading] = useState(false);
   const [wechatLoading, setWechatLoading] = useState(false);
+  const [disabledProviders, setDisabledProviders] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchOAuthProviders().then((res) => {
+      if (cancelled || !res.ok || !Array.isArray(res.data)) return;
+      const enabled = new Set(res.data.map((p) => p.provider));
+      const disabled = new Set<string>();
+      for (const name of ['github', 'microsoft', 'wechat']) {
+        if (!enabled.has(name)) disabled.add(name);
+      }
+      setDisabledProviders(disabled);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   const handleGitHubLogin = async (): Promise<void> => {
     if (githubLoading) return;
@@ -362,6 +377,7 @@ export function useLogin() {
     handleMicrosoftLogin,
     wechatLoading,
     handleWechatLogin,
+    disabledProviders,
     t,
   };
 }

--- a/src/renderer/components/states/login/hooks/useLogin.ts
+++ b/src/renderer/components/states/login/hooks/useLogin.ts
@@ -207,7 +207,7 @@ export function useLogin() {
     let cancelled = false;
     void fetchOAuthProviders().then((res) => {
       if (cancelled || !res.ok || !Array.isArray(res.data)) return;
-      const enabled = new Set(res.data.map((p) => p.provider));
+      const enabled = new Set(res.data.map((p) => p.provider.toLowerCase()));
       const allProviders = ['github', 'microsoft', 'wechat'] as const;
       setDisabledProviders(new Set(allProviders.filter((name) => !enabled.has(name))));
     });

--- a/src/renderer/components/states/login/hooks/useLogin.ts
+++ b/src/renderer/components/states/login/hooks/useLogin.ts
@@ -208,11 +208,8 @@ export function useLogin() {
     void fetchOAuthProviders().then((res) => {
       if (cancelled || !res.ok || !Array.isArray(res.data)) return;
       const enabled = new Set(res.data.map((p) => p.provider));
-      const disabled = new Set<string>();
-      for (const name of ['github', 'microsoft', 'wechat']) {
-        if (!enabled.has(name)) disabled.add(name);
-      }
-      setDisabledProviders(disabled);
+      const allProviders = ['github', 'microsoft', 'wechat'] as const;
+      setDisabledProviders(new Set(allProviders.filter((name) => !enabled.has(name))));
     });
     return () => { cancelled = true; };
   }, []);

--- a/src/renderer/components/states/login/types/index.ts
+++ b/src/renderer/components/states/login/types/index.ts
@@ -32,6 +32,7 @@ import type { Feedback } from '../config/loginConfig';
 export interface LoginFormProps {
   account: string;
   setAccount: Dispatch<SetStateAction<string>>;
+  verificationEmail: string;
   maskedVerificationEmail: string;
   emailCode: string;
   setEmailCode: Dispatch<SetStateAction<string>>;
@@ -56,5 +57,6 @@ export interface LoginFormProps {
   handleMicrosoftLogin: () => Promise<void>;
   wechatLoading: boolean;
   handleWechatLogin: () => Promise<void>;
+  disabledProviders: Set<string>;
   t: TFunction;
 }

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -32,6 +32,7 @@ import {
   fetchUserPaymentOrders,
   fetchProMonthPricing,
   fetchAgentBalance,
+  fetchOAuthBindings,
   fetchUserProfile,
   logoutUser,
   refreshUserToken,
@@ -40,6 +41,7 @@ import {
   updateUserPassword,
   updateUserProfile,
   uploadUserAvatar,
+  type OAuthBindingItem,
   type UserPaymentOrderData,
 } from '../../../../../../../api/user/userAccountApi';
 import { runSliderCaptcha } from '../../../../../../../utils/sliderCaptcha';
@@ -182,6 +184,10 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [rechargeCustomValue, setRechargeCustomValue] = useState('');
   const [rechargeFeedback, setRechargeFeedback] = useState<Feedback | null>(null);
   const [userBalance, setUserBalance] = useState<string | null>(null);
+
+  /** 第三方应用绑定列表 */
+  const [oauthBindings, setOauthBindings] = useState<OAuthBindingItem[]>([]);
+  const [loadingOAuthBindings, setLoadingOAuthBindings] = useState(false);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -545,6 +551,24 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
     void loadUserOrders();
   }, [loadUserOrders, token, userProfilePage]);
+
+  useEffect(() => {
+    if (userProfilePage !== 'oauth' || !token) {
+      return;
+    }
+    let cancelled = false;
+    const loadOAuthBindings = async (): Promise<void> => {
+      setLoadingOAuthBindings(true);
+      const result = await fetchOAuthBindings(token);
+      if (cancelled) return;
+      setLoadingOAuthBindings(false);
+      if (result.ok && Array.isArray(result.data)) {
+        setOauthBindings(result.data);
+      }
+    };
+    void loadOAuthBindings();
+    return () => { cancelled = true; };
+  }, [token, userProfilePage]);
 
   const handleSaveProfile = async (): Promise<void> => {
     if (!token || savingProfile || savingPassword) return;
@@ -1617,8 +1641,70 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
     const RECHARGE_PRESETS = [1, 10, 30, 50, 100];
 
+    const getProviderIcon = (provider: string): string => {
+      const p = provider.toLowerCase();
+      if (p === 'github') return SvgIcon.GITHUB;
+      if (p === 'microsoft') return SvgIcon.MICROSOFT;
+      if (p === 'wechat') return SvgIcon.WECHAT;
+      return SvgIcon.LINK;
+    };
+
+    const getProviderLabel = (provider: string): string => {
+      const p = provider.toLowerCase();
+      if (p === 'github') return 'GitHub';
+      if (p === 'microsoft') return 'Microsoft';
+      if (p === 'wechat') return t('settings.user.oauth.provider.wechat', { defaultValue: '微信' });
+      return provider;
+    };
+
     const renderOAuthPage = (): ReactElement => (
       <div className="settings-user-page-panel settings-user-oauth-panel">
+        <div className="settings-user-card settings-user-oauth-head-card">
+          <div className="settings-user-form-title">{t('settings.user.pages.oauth', { defaultValue: '第三方应用绑定' })}</div>
+          <div className="settings-user-card-title-hint">
+            {t('settings.user.oauth.subtitle', { defaultValue: '管理已绑定的第三方登录账号' })}
+          </div>
+        </div>
+
+        {loadingOAuthBindings && oauthBindings.length === 0 ? (
+          <div className="settings-user-card settings-user-oauth-empty">
+            <span className="settings-user-orders-inline-spinner" aria-hidden="true" />
+            <span>{t('settings.user.oauth.loading', { defaultValue: '加载中…' })}</span>
+          </div>
+        ) : null}
+
+        {!loadingOAuthBindings && oauthBindings.length === 0 ? (
+          <div className="settings-user-card settings-user-oauth-empty">
+            {t('settings.user.oauth.empty', { defaultValue: '暂无第三方绑定' })}
+          </div>
+        ) : null}
+
+        {oauthBindings.map((binding) => (
+          <div key={binding.id} className="settings-user-card settings-user-oauth-item-card">
+            <div className="settings-user-oauth-item-header">
+              <img
+                className="settings-user-oauth-provider-icon"
+                src={getProviderIcon(binding.provider)}
+                alt={binding.provider}
+              />
+              <span className="settings-user-oauth-provider-name">{getProviderLabel(binding.provider)}</span>
+            </div>
+            <div className="settings-user-oauth-item-detail">
+              <div className="settings-user-oauth-item-row">
+                <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.username', { defaultValue: '用户名' })}</span>
+                <span className="settings-user-oauth-item-value">{binding.providerUsername ?? '—'}</span>
+              </div>
+              <div className="settings-user-oauth-item-row">
+                <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.email', { defaultValue: '邮箱' })}</span>
+                <span className="settings-user-oauth-item-value">{binding.providerEmail ?? '—'}</span>
+              </div>
+              <div className="settings-user-oauth-item-row">
+                <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.boundAt', { defaultValue: '绑定时间' })}</span>
+                <span className="settings-user-oauth-item-value">{formatDateTime(binding.createdAt)}</span>
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     );
 

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -1734,7 +1734,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               <button
                 type="button"
                 className="settings-user-danger-btn"
-                disabled={oauthUnbindingId !== null}
+                disabled={oauthUnbindingId === binding.id}
                 onClick={() => void handleUnbindOAuth(binding.id)}
               >
                 {oauthUnbindingId === binding.id

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -1206,6 +1206,11 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               <span className="settings-index-card-desc">{t('settings.user.infoNav.passwordDesc', { defaultValue: '通过邮箱验证码修改登录密码' })}</span>
               <img className="settings-index-card-layout-icon" src={SvgIcon.SHORTCUT_KEY} alt="" aria-hidden="true" />
             </button>
+            <button type="button" className="settings-index-card" onClick={() => setUserProfilePage('oauth')}>
+              <span className="settings-index-card-title">{t('settings.user.pages.oauth', { defaultValue: '第三方应用绑定' })}</span>
+              <span className="settings-index-card-desc">{t('settings.user.infoNav.oauthDesc', { defaultValue: '查看已绑定的第三方登录账号' })}</span>
+              <img className="settings-index-card-layout-icon" src={SvgIcon.LINK} alt="" aria-hidden="true" />
+            </button>
             <button
               type="button"
               className="settings-index-card"
@@ -1695,8 +1700,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                 <span className="settings-user-oauth-item-value">{binding.providerUsername ?? '—'}</span>
               </div>
               <div className="settings-user-oauth-item-row">
-                <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.email', { defaultValue: '邮箱' })}</span>
-                <span className="settings-user-oauth-item-value">{binding.providerEmail ?? '—'}</span>
+                <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.providerUserId', { defaultValue: '第三方用户ID' })}</span>
+                <span className="settings-user-oauth-item-value">{binding.providerUserId ?? '—'}</span>
               </div>
               <div className="settings-user-oauth-item-row">
                 <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.boundAt', { defaultValue: '绑定时间' })}</span>

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -60,7 +60,7 @@ import { readLoginDays, recordLoginDay } from './utils/loginHeatmapStorage';
 import '../../../../../../../styles/settings/modules/cli.css';
 
 type FeedbackType = 'success' | 'error' | 'info';
-type UserProfilePage = 'info' | 'edit' | 'password' | 'pro' | 'recharge' | 'orders' | 'account';
+type UserProfilePage = 'info' | 'edit' | 'password' | 'pro' | 'recharge' | 'orders' | 'account' | 'oauth';
 
 interface Feedback {
   type: FeedbackType;
@@ -74,7 +74,7 @@ interface UserSettingsSectionProps {
 }
 
 const GENDER_VALUES: UserAccountGender[] = ['male', 'female', 'custom', 'undisclosed'];
-const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account'];
+const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account', 'oauth'];
 const EMAIL_PATTERN = /^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 
 const getGenderIcon = (gender: UserAccountGender | null | undefined): string => {
@@ -201,7 +201,9 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               ? '余额充值'
               : userProfilePage === 'orders'
                 ? '我的订单'
-                : '关于账户',
+                : userProfilePage === 'account'
+                  ? '关于账户'
+                  : '第三方应用绑定',
   });
 
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
@@ -1043,6 +1045,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       { id: 'recharge', label: t('settings.user.pages.recharge', { defaultValue: '余额充值' }) },
       { id: 'orders', label: t('settings.user.pages.orders', { defaultValue: '我的订单' }) },
       { id: 'account', label: t('settings.user.pages.account', { defaultValue: '关于账户' }) },
+      { id: 'oauth', label: t('settings.user.pages.oauth', { defaultValue: '第三方应用绑定' }) },
     ];
     const profileRole = (profile as { role?: unknown } | null)?.role;
     const normalizedProfileRole = typeof profileRole === 'string' ? normalizeRoleValue(profileRole) : null;
@@ -1614,6 +1617,11 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
     const RECHARGE_PRESETS = [1, 10, 30, 50, 100];
 
+    const renderOAuthPage = (): ReactElement => (
+      <div className="settings-user-page-panel settings-user-oauth-panel">
+      </div>
+    );
+
     const rechargeAmountYuan = rechargeSelected !== null && rechargeSelected !== undefined
       ? rechargeSelected
       : (rechargeCustomValue.trim() !== '' ? parseFloat(rechargeCustomValue) : NaN);
@@ -1703,6 +1711,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
           {userProfilePage === 'recharge' && renderRechargePage()}
           {userProfilePage === 'orders' && renderOrdersPage()}
           {userProfilePage === 'account' && renderAccountPage()}
+          {userProfilePage === 'oauth' && renderOAuthPage()}
         </div>
 
         <div className="settings-user-page-dots">

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -37,6 +37,7 @@ import {
   logoutUser,
   refreshUserToken,
   sendUserEmailCode,
+  unbindOAuth,
   unregisterUser,
   updateUserPassword,
   updateUserProfile,
@@ -188,6 +189,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   /** 第三方应用绑定列表 */
   const [oauthBindings, setOauthBindings] = useState<OAuthBindingItem[]>([]);
   const [loadingOAuthBindings, setLoadingOAuthBindings] = useState(false);
+  const [oauthUnbindingId, setOauthUnbindingId] = useState<number | null>(null);
+  const [oauthFeedback, setOauthFeedback] = useState<{ bindingId: number; feedback: Feedback } | null>(null);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -569,6 +572,24 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     void loadOAuthBindings();
     return () => { cancelled = true; };
   }, [token, userProfilePage]);
+
+  const handleUnbindOAuth = async (bindingId: number): Promise<void> => {
+    if (!token || oauthUnbindingId !== null) return;
+    setOauthUnbindingId(bindingId);
+    setOauthFeedback(null);
+    const result = await unbindOAuth(token, bindingId);
+    setOauthUnbindingId(null);
+    if (!result.ok) {
+      if (result.code === 401 || result.code === 4011) {
+        resetToLoggedOut();
+        return;
+      }
+      setOauthFeedback({ bindingId, feedback: { type: 'error', text: result.message || t('settings.user.oauth.feedback.unbindFailed', { defaultValue: '解除绑定失败' }) } });
+      return;
+    }
+    setOauthBindings((prev) => prev.filter((b) => b.id !== bindingId));
+    setOauthFeedback(null);
+  };
 
   const handleSaveProfile = async (): Promise<void> => {
     if (!token || savingProfile || savingPassword) return;
@@ -1707,6 +1728,19 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                 <span className="settings-user-oauth-item-label">{t('settings.user.oauth.fields.boundAt', { defaultValue: '绑定时间' })}</span>
                 <span className="settings-user-oauth-item-value">{formatDateTime(binding.createdAt)}</span>
               </div>
+            </div>
+            {oauthFeedback?.bindingId === binding.id ? renderFeedback(oauthFeedback.feedback) : null}
+            <div className="settings-user-oauth-item-actions">
+              <button
+                type="button"
+                className="settings-user-danger-btn"
+                disabled={oauthUnbindingId !== null}
+                onClick={() => void handleUnbindOAuth(binding.id)}
+              >
+                {oauthUnbindingId === binding.id
+                  ? t('settings.user.oauth.actions.unbinding', { defaultValue: '解除中…' })
+                  : t('settings.user.oauth.actions.unbind', { defaultValue: '解除绑定' })}
+              </button>
             </div>
           </div>
         ))}

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5336,6 +5336,20 @@
   white-space: nowrap;
 }
 
+.settings-user-oauth-item-card .settings-user-feedback {
+  margin-top: 8px;
+}
+
+.settings-user-oauth-item-actions {
+  display: flex;
+  margin-top: 10px;
+}
+
+.settings-user-oauth-item-actions .settings-user-danger-btn {
+  flex: 1;
+  justify-content: center;
+}
+
 @media (max-width: 760px) {
   .settings-user-avatar-row {
     grid-template-columns: 1fr;

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5262,6 +5262,80 @@
   justify-content: center;
 }
 
+/* ── OAuth Bindings Page ── */
+
+.settings-user-oauth-panel {
+  gap: 10px;
+}
+
+.settings-user-oauth-head-card {
+  gap: 8px;
+}
+
+.settings-user-oauth-empty {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(var(--color-text-rgb), 0.56);
+}
+
+.settings-user-oauth-item-card {
+  gap: 0;
+}
+
+.settings-user-oauth-item-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 10px;
+}
+
+.settings-user-oauth-provider-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
+.settings-user-oauth-provider-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(var(--color-text-rgb), 0.92);
+}
+
+.settings-user-oauth-item-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(var(--color-text-rgb), 0.04);
+}
+
+.settings-user-oauth-item-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-user-oauth-item-label {
+  font-size: 11px;
+  color: rgba(var(--color-text-rgb), 0.56);
+}
+
+.settings-user-oauth-item-value {
+  font-size: 12px;
+  color: rgba(var(--color-text-rgb), 0.86);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 760px) {
   .settings-user-avatar-row {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Add OAuth account management to user settings and align login UI with server-configured OAuth providers.

New Features:
- Introduce a dedicated user settings page for viewing and managing third-party OAuth account bindings, including unbinding support.
- Expose API endpoints in the renderer for listing a user’s OAuth bindings and available OAuth login providers.
- Display provider-specific metadata (username, ID, bound time) and icons for each bound OAuth account in the settings UI.

Enhancements:
- Update the login flow and form to respect the server-provided list of enabled OAuth providers, disabling unsupported provider buttons in the UI.
- Extend user settings navigation and shortcuts to include the new third-party bindings management page.
- Add styling for the OAuth bindings management cards and list within the settings layout.