### PR TITLE
refactor: 重构剪贴板历史记录分页代码架构

### DIFF
--- a/src/renderer/components/components/StandaloneWindowViewport.tsx
+++ b/src/renderer/components/components/StandaloneWindowViewport.tsx
@@ -31,7 +31,7 @@ import { UrlFavoritesTab } from '../states/maxExpand/components/UrlFavoritesTab'
 import { AlbumTab } from '../states/maxExpand/components/album/components/AlbumTab';
 import { MailTab } from '../states/maxExpand/components/MailTab';
 import { LocalFileSearchTab } from '../states/maxExpand/components/LocalFileSearchTab';
-import { ClipboardHistoryTab } from '../states/maxExpand/components/ClipboardHistoryTab';
+import { ClipboardHistoryTab } from '../states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab';
 import { SettingsTab } from '../states/maxExpand/components/SettingsTab';
 import { MemoTab } from '../states/maxExpand/components/MemoTab';
 import { AlarmTab } from '../states/maxExpand/components/alarm/components/AlarmTab';

--- a/src/renderer/components/components/StandaloneWindowViewport.tsx
+++ b/src/renderer/components/components/StandaloneWindowViewport.tsx
@@ -31,7 +31,7 @@ import { UrlFavoritesTab } from '../states/maxExpand/components/UrlFavoritesTab'
 import { AlbumTab } from '../states/maxExpand/components/album/components/AlbumTab';
 import { MailTab } from '../states/maxExpand/components/MailTab';
 import { LocalFileSearchTab } from '../states/maxExpand/components/LocalFileSearchTab';
-import { ClipboardHistoryTab } from '../states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab';
+import { ClipboardHistoryTab } from '../states/maxExpand/components/clipBoardHistory';
 import { SettingsTab } from '../states/maxExpand/components/SettingsTab';
 import { MemoTab } from '../states/maxExpand/components/MemoTab';
 import { AlarmTab } from '../states/maxExpand/components/alarm/components/AlarmTab';

--- a/src/renderer/components/states/maxExpand/MaxExpandContentEager.tsx
+++ b/src/renderer/components/states/maxExpand/MaxExpandContentEager.tsx
@@ -31,7 +31,7 @@ import { AiChatTab } from './components/agent/components/AiChatTab';
 import { TodoTab } from './components/TodoTab';
 import { UrlFavoritesTab } from './components/UrlFavoritesTab';
 import { LocalFileSearchTab } from './components/LocalFileSearchTab';
-import { ClipboardHistoryTab } from './components/ClipboardHistoryTab';
+import { ClipboardHistoryTab } from './components/clipBoardHistory/components/ClipboardHistoryTab';
 import { AlbumTab } from './components/album/components/AlbumTab';
 import { MailTab } from './components/MailTab';
 import { SettingsTab } from './components/SettingsTab';

--- a/src/renderer/components/states/maxExpand/MaxExpandContentEager.tsx
+++ b/src/renderer/components/states/maxExpand/MaxExpandContentEager.tsx
@@ -31,7 +31,7 @@ import { AiChatTab } from './components/agent/components/AiChatTab';
 import { TodoTab } from './components/TodoTab';
 import { UrlFavoritesTab } from './components/UrlFavoritesTab';
 import { LocalFileSearchTab } from './components/LocalFileSearchTab';
-import { ClipboardHistoryTab } from './components/clipBoardHistory/components/ClipboardHistoryTab';
+import { ClipboardHistoryTab } from './components/clipBoardHistory';
 import { AlbumTab } from './components/album/components/AlbumTab';
 import { MailTab } from './components/MailTab';
 import { SettingsTab } from './components/SettingsTab';

--- a/src/renderer/components/states/maxExpand/MaxExpandContentLazy.tsx
+++ b/src/renderer/components/states/maxExpand/MaxExpandContentLazy.tsx
@@ -33,7 +33,7 @@ const AiChatTab = lazy(() => import('./components/agent/components/AiChatTab').t
 const TodoTab = lazy(() => import('./components/TodoTab').then((module) => ({ default: module.TodoTab })));
 const UrlFavoritesTab = lazy(() => import('./components/UrlFavoritesTab').then((module) => ({ default: module.UrlFavoritesTab })));
 const LocalFileSearchTab = lazy(() => import('./components/LocalFileSearchTab').then((module) => ({ default: module.LocalFileSearchTab })));
-const ClipboardHistoryTab = lazy(() => import('./components/ClipboardHistoryTab').then((module) => ({ default: module.ClipboardHistoryTab })));
+const ClipboardHistoryTab = lazy(() => import('./components/clipBoardHistory/components/ClipboardHistoryTab').then((module) => ({ default: module.ClipboardHistoryTab })));
 const AlbumTab = lazy(() => import('./components/album/components/AlbumTab').then((module) => ({ default: module.AlbumTab })));
 const MailTab = lazy(() => import('./components/MailTab').then((module) => ({ default: module.MailTab })));
 const SettingsTab = lazy(() => import('./components/SettingsTab').then((module) => ({ default: module.SettingsTab })));

--- a/src/renderer/components/states/maxExpand/MaxExpandContentLazy.tsx
+++ b/src/renderer/components/states/maxExpand/MaxExpandContentLazy.tsx
@@ -33,7 +33,7 @@ const AiChatTab = lazy(() => import('./components/agent/components/AiChatTab').t
 const TodoTab = lazy(() => import('./components/TodoTab').then((module) => ({ default: module.TodoTab })));
 const UrlFavoritesTab = lazy(() => import('./components/UrlFavoritesTab').then((module) => ({ default: module.UrlFavoritesTab })));
 const LocalFileSearchTab = lazy(() => import('./components/LocalFileSearchTab').then((module) => ({ default: module.LocalFileSearchTab })));
-const ClipboardHistoryTab = lazy(() => import('./components/clipBoardHistory/components/ClipboardHistoryTab').then((module) => ({ default: module.ClipboardHistoryTab })));
+const ClipboardHistoryTab = lazy(() => import('./components/clipBoardHistory').then((module) => ({ default: module.ClipboardHistoryTab })));
 const AlbumTab = lazy(() => import('./components/album/components/AlbumTab').then((module) => ({ default: module.AlbumTab })));
 const MailTab = lazy(() => import('./components/MailTab').then((module) => ({ default: module.MailTab })));
 const SettingsTab = lazy(() => import('./components/SettingsTab').then((module) => ({ default: module.SettingsTab })));

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryBulkBar.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryBulkBar.tsx
@@ -1,0 +1,91 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file ClipboardHistoryBulkBar.tsx
+ * @description 剪贴板历史批量操作栏：全选、删除已选、时间范围清理。
+ * @author 鸡哥
+ */
+
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClipboardHistoryBulkBarProps, ClipboardCleanupRange } from '../types/clipboardHistoryTypes';
+
+/**
+ * 剪贴板历史批量操作栏
+ */
+export function ClipboardHistoryBulkBar({
+  selectionCollapsing,
+  allSelected,
+  totalCount,
+  selectedCount,
+  cleanupRange,
+  cleanupMatchedCount,
+  onToggleSelectAll,
+  onRemoveSelected,
+  onCleanupRangeChange,
+  onClearByRange,
+}: ClipboardHistoryBulkBarProps): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className={`clipboard-history-bulk-bar${selectionCollapsing ? ' clipboard-history-bulk-bar--collapsing' : ''}`}>
+      <label className="clipboard-history-select-all">
+        <input
+          type="checkbox"
+          checked={allSelected}
+          disabled={totalCount === 0}
+          onChange={onToggleSelectAll}
+        />
+        <span>{t('clipboardHistoryTab.actions.selectAll', { defaultValue: '全选' })}</span>
+      </label>
+      <button
+        className="clipboard-history-bulk-delete"
+        type="button"
+        onClick={onRemoveSelected}
+        disabled={selectedCount === 0}
+      >
+        {t('clipboardHistoryTab.actions.deleteSelected', { defaultValue: '删除已选' })}
+        {selectedCount > 0 ? ` (${selectedCount})` : ''}
+      </button>
+      <select
+        className="clipboard-history-range-select"
+        value={cleanupRange}
+        onChange={(e) => onCleanupRangeChange(e.target.value as ClipboardCleanupRange)}
+        aria-label={t('clipboardHistoryTab.actions.rangeAria', { defaultValue: '选择清理时间范围' })}
+      >
+        <option value="lastHour">{t('clipboardHistoryTab.ranges.lastHour', { defaultValue: '最近 1 小时' })}</option>
+        <option value="today">{t('clipboardHistoryTab.ranges.today', { defaultValue: '今天' })}</option>
+        <option value="last7Days">{t('clipboardHistoryTab.ranges.last7Days', { defaultValue: '最近 7 天' })}</option>
+        <option value="last30Days">{t('clipboardHistoryTab.ranges.last30Days', { defaultValue: '最近 30 天' })}</option>
+        <option value="olderThan30Days">{t('clipboardHistoryTab.ranges.olderThan30Days', { defaultValue: '30 天前' })}</option>
+      </select>
+      <button
+        className="clipboard-history-range-clear"
+        type="button"
+        onClick={onClearByRange}
+        disabled={cleanupMatchedCount === 0}
+      >
+        {t('clipboardHistoryTab.actions.clearRange', { defaultValue: '清理范围' })}
+        {cleanupMatchedCount > 0 ? ` (${cleanupMatchedCount})` : ''}
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryHeader.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryHeader.tsx
@@ -51,14 +51,13 @@ export function ClipboardHistoryHeader({
       <span className="clipboard-history-title">{t('clipboardHistoryTab.title', { defaultValue: '剪贴板历史' })}</span>
       <div className="clipboard-history-header-right">
         <span className="clipboard-history-count">{countLabel}</span>
-        <div className="clipboard-history-filter-bar" role="tablist" aria-label={t('clipboardHistoryTab.filters.aria', { defaultValue: '剪贴板类型筛选' })}>
+        <div className="clipboard-history-filter-bar" aria-label={t('clipboardHistoryTab.filters.aria', { defaultValue: '剪贴板类型筛选' })}>
           {CLIPBOARD_HISTORY_FILTERS.map((filter) => (
             <button
               key={filter}
               className={`clipboard-history-filter${activeFilter === filter ? ' clipboard-history-filter--active' : ''}`}
               type="button"
-              role="tab"
-              aria-selected={activeFilter === filter}
+              aria-pressed={activeFilter === filter}
               onClick={() => onFilterChange(filter)}
             >
               {t(CLIPBOARD_HISTORY_FILTER_LABEL_KEYS[filter], {

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryHeader.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryHeader.tsx
@@ -1,0 +1,103 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file ClipboardHistoryHeader.tsx
+ * @description 剪贴板历史头部栏：标题、计数、筛选、操作按钮。
+ * @author 鸡哥
+ */
+
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClipboardHistoryHeaderProps } from '../types/clipboardHistoryTypes';
+import { CLIPBOARD_HISTORY_FILTER_DEFAULT_LABELS, CLIPBOARD_HISTORY_FILTER_LABEL_KEYS, CLIPBOARD_HISTORY_FILTERS } from '../types/clipboardHistoryTypes';
+
+/**
+ * 剪贴板历史头部栏
+ */
+export function ClipboardHistoryHeader({
+  totalCount,
+  activeFilter,
+  exportCount,
+  selectionMode,
+  selectedCount,
+  countLabel,
+  onFilterChange,
+  onClear,
+  onExport,
+  onToggleSelectionMode,
+}: ClipboardHistoryHeaderProps): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className="clipboard-history-header">
+      <span className="clipboard-history-title">{t('clipboardHistoryTab.title', { defaultValue: '剪贴板历史' })}</span>
+      <div className="clipboard-history-header-right">
+        <span className="clipboard-history-count">{countLabel}</span>
+        <div className="clipboard-history-filter-bar" role="tablist" aria-label={t('clipboardHistoryTab.filters.aria', { defaultValue: '剪贴板类型筛选' })}>
+          {CLIPBOARD_HISTORY_FILTERS.map((filter) => (
+            <button
+              key={filter}
+              className={`clipboard-history-filter${activeFilter === filter ? ' clipboard-history-filter--active' : ''}`}
+              type="button"
+              role="tab"
+              aria-selected={activeFilter === filter}
+              onClick={() => onFilterChange(filter)}
+            >
+              {t(CLIPBOARD_HISTORY_FILTER_LABEL_KEYS[filter], {
+                defaultValue: CLIPBOARD_HISTORY_FILTER_DEFAULT_LABELS[filter],
+              })}
+            </button>
+          ))}
+        </div>
+        <button
+          className="clipboard-history-clear"
+          type="button"
+          onClick={onClear}
+          disabled={totalCount === 0}
+        >
+          {t('clipboardHistoryTab.actions.clear', { defaultValue: '清空' })}
+        </button>
+        <button
+          className="clipboard-history-export"
+          type="button"
+          onClick={onExport}
+          disabled={exportCount === 0}
+          title={selectionMode && selectedCount > 0
+            ? t('clipboardHistoryTab.actions.exportSelectedTitle', { defaultValue: '导出已选记录' })
+            : t('clipboardHistoryTab.actions.exportAllTitle', { defaultValue: '导出全部记录' })}
+        >
+          {t('clipboardHistoryTab.actions.export', { defaultValue: '导出' })}
+          {selectionMode && selectedCount > 0 ? ` (${selectedCount})` : ''}
+        </button>
+        <button
+          className={`clipboard-history-select-toggle${selectionMode ? ' clipboard-history-select-toggle--active' : ''}`}
+          type="button"
+          onClick={onToggleSelectionMode}
+          disabled={totalCount === 0}
+        >
+          {selectionMode
+            ? t('clipboardHistoryTab.actions.cancelSelect', { defaultValue: '取消' })
+            : t('clipboardHistoryTab.actions.select', { defaultValue: '选择' })}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryItemRow.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryItemRow.tsx
@@ -1,0 +1,131 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file ClipboardHistoryItemRow.tsx
+ * @description 剪贴板历史单条记录行：摘要行 + 展开编辑区。
+ * @author 鸡哥
+ */
+
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SvgIcon } from '../../../../../../utils/SvgIcon';
+import type { ClipboardHistoryItemRowProps } from '../types/clipboardHistoryTypes';
+import { getPreviewText } from '../utils/clipboardHistoryUtils';
+
+/**
+ * 剪贴板历史单条记录行
+ */
+export function ClipboardHistoryItemRow({
+  item,
+  expanded,
+  selected,
+  selectionMode,
+  selectionCollapsing,
+  editText,
+  editTextareaRef,
+  onToggleSelect,
+  onCopy,
+  onToggleExpand,
+  onEditTextChange,
+  onEditTextareaRef,
+  onSaveEdit,
+  onRemove,
+}: ClipboardHistoryItemRowProps): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className={`clipboard-history-item${selectionMode && !selectionCollapsing && selected ? ' clipboard-history-item--selected' : ''}`}>
+      <div className={`clipboard-history-summary-row${selectionMode ? ' clipboard-history-summary-row--selecting' : ''}${selectionCollapsing ? ' clipboard-history-summary-row--collapsing' : ''}`}>
+        {selectionMode ? (
+          <label className="clipboard-history-item-check">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={() => onToggleSelect(item.id)}
+              aria-label={t('clipboardHistoryTab.actions.selectItemAria', { defaultValue: '选择该剪贴板记录' })}
+            />
+          </label>
+        ) : null}
+        <button
+          className="clipboard-history-copy"
+          type="button"
+          onClick={() => onCopy(item)}
+          aria-label={t('clipboardHistoryTab.actions.copyAria', { defaultValue: '复制该记录到剪贴板' })}
+          title={t('clipboardHistoryTab.actions.copyTitle', { defaultValue: '复制到剪贴板' })}
+        >
+          <img src={SvgIcon.COPY} alt="" aria-hidden="true" />
+        </button>
+        <button
+          className="clipboard-history-summary"
+          type="button"
+          onClick={() => onToggleExpand(item)}
+          title={item.text}
+        >
+          <span className="clipboard-history-preview">{getPreviewText(item.text)}</span>
+          <span className="clipboard-history-time">{new Date(item.createdAt).toLocaleString()}</span>
+          <span className="clipboard-history-expand-indicator">
+            {expanded
+              ? t('clipboardHistoryTab.actions.collapse', { defaultValue: '收起' })
+              : t('clipboardHistoryTab.actions.expand', { defaultValue: '展开' })}
+          </span>
+        </button>
+      </div>
+
+      {expanded ? (
+        <div className="clipboard-history-detail">
+          <textarea
+            className="clipboard-history-content"
+            value={editText}
+            ref={editTextareaRef}
+            onChange={(e) => {
+              onEditTextChange(e.target.value);
+              onEditTextareaRef(e.currentTarget);
+            }}
+            onKeyDown={(e) => {
+              if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                onSaveEdit(item.id);
+              }
+            }}
+          />
+          <div className="clipboard-history-actions">
+            <button
+              className="clipboard-history-save"
+              type="button"
+              onClick={() => onSaveEdit(item.id)}
+              disabled={!editText.trim()}
+            >
+              {t('clipboardHistoryTab.actions.save', { defaultValue: '保存' })}
+            </button>
+            <button
+              className="clipboard-history-remove"
+              type="button"
+              onClick={() => onRemove(item.id)}
+              aria-label={t('clipboardHistoryTab.actions.removeAria', { defaultValue: '删除该剪贴板记录' })}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryItemRow.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryItemRow.tsx
@@ -89,43 +89,45 @@ export function ClipboardHistoryItemRow({
         </button>
       </div>
 
-      {expanded ? (
-        <div className="clipboard-history-detail">
-          <textarea
-            className="clipboard-history-content"
-            value={editText}
-            ref={editTextareaRef}
-            onChange={(e) => {
-              onEditTextChange(e.target.value);
-              onEditTextareaRef(e.currentTarget);
-            }}
-            onKeyDown={(e) => {
-              if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                e.preventDefault();
-                onSaveEdit(item.id);
-              }
-            }}
-          />
-          <div className="clipboard-history-actions">
-            <button
-              className="clipboard-history-save"
-              type="button"
-              onClick={() => onSaveEdit(item.id)}
-              disabled={!editText.trim()}
-            >
-              {t('clipboardHistoryTab.actions.save', { defaultValue: '保存' })}
-            </button>
-            <button
-              className="clipboard-history-remove"
-              type="button"
-              onClick={() => onRemove(item.id)}
-              aria-label={t('clipboardHistoryTab.actions.removeAria', { defaultValue: '删除该剪贴板记录' })}
-            >
-              ×
-            </button>
+      <div className={`clipboard-history-detail-wrapper${expanded ? ' clipboard-history-detail-wrapper--expanded' : ''}`}>
+        <div className="clipboard-history-detail-inner">
+          <div className="clipboard-history-detail">
+            <textarea
+              className="clipboard-history-content"
+              value={editText}
+              ref={editTextareaRef}
+              onChange={(e) => {
+                onEditTextChange(e.target.value);
+                onEditTextareaRef(e.currentTarget);
+              }}
+              onKeyDown={(e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                  e.preventDefault();
+                  onSaveEdit(item.id);
+                }
+              }}
+            />
+            <div className="clipboard-history-actions">
+              <button
+                className="clipboard-history-save"
+                type="button"
+                onClick={() => onSaveEdit(item.id)}
+                disabled={!editText.trim()}
+              >
+                {t('clipboardHistoryTab.actions.save', { defaultValue: '保存' })}
+              </button>
+              <button
+                className="clipboard-history-remove"
+                type="button"
+                onClick={() => onRemove(item.id)}
+                aria-label={t('clipboardHistoryTab.actions.removeAria', { defaultValue: '删除该剪贴板记录' })}
+              >
+                ×
+              </button>
+            </div>
           </div>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
@@ -30,7 +30,7 @@ import { useTranslation } from 'react-i18next';
 import { useClipboardHistoryFeedback } from '../hooks/useClipboardHistoryFeedback';
 import { useClipboardHistoryItems } from '../hooks/useClipboardHistoryItems';
 import { useClipboardHistorySelection } from '../hooks/useClipboardHistorySelection';
-import { buildClipboardHistoryExport, downloadTextFile, getClipboardHistoryExportFileName, matchesClipboardFilter } from '../utils/clipboardHistoryUtils';
+import { buildClipboardHistoryExport, downloadTextFile, getClipboardHistoryExportFileName } from '../utils/clipboardHistoryUtils';
 import { ClipboardHistoryBulkBar } from './ClipboardHistoryBulkBar';
 import { ClipboardHistoryHeader } from './ClipboardHistoryHeader';
 import { ClipboardHistoryItemRow } from './ClipboardHistoryItemRow';
@@ -54,18 +54,13 @@ export function ClipboardHistoryTab(): ReactElement {
   /* ── Hook: 选择模式 ── */
   const {
     selectedIds, selectionMode, selectionCollapsing, cleanupRange,
-    activeFilter, selectedCount, selectedIdSet, allSelected,
+    activeFilter, selectedCount, selectedIdSet, visibleItems, allSelected,
     cleanupMatchedCount, handleToggleSelectionMode,
     handleToggleSelect, handleToggleSelectAll,
     handleCleanupRangeChange, handleFilterChange,
     handleRemoveSelected, handleClearByRange,
   } = useClipboardHistorySelection(items, setItems, expandedId, setExpandedId, setEditText);
 
-  /* ── 筛选后可见条目 ── */
-  const visibleItems = useMemo(
-    () => items.filter((item) => matchesClipboardFilter(item, activeFilter)),
-    [activeFilter, items],
-  );
   const totalCount = items.length;
   const visibleCount = visibleItems.length;
 

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
@@ -20,318 +20,56 @@
 
 /**
  * @file ClipboardHistoryTab.tsx
- * @description 最大展开模式剪贴板历史 Tab
+ * @description 最大展开模式剪贴板历史页主组件：仅负责 hook 调用与组件组合。
  * @author 鸡哥
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SvgIcon } from '../../../../../../utils/SvgIcon';
-import useIslandStore from '../../../../../../store/slices';
-
-interface ClipboardHistoryItem {
-  id: number;
-  text: string;
-  createdAt: number;
-}
-
-const STORE_KEY = 'clipboard-history-recent';
-const LOCAL_STORAGE_KEY = 'eIsland_clipboard_history_recent';
-const HISTORY_ENABLED_STORE_KEY = 'clipboard-history-enabled';
-const HISTORY_LIMIT_STORE_KEY = 'clipboard-history-limit';
-const EXIT_MAX_EXPAND_ON_COPY_STORE_KEY = 'clipboard-history-exit-max-expand-on-copy';
-const DEFAULT_HISTORY_LIMIT = 10;
-const POLL_INTERVAL_MS = 1000;
-const SELECTION_COLLAPSE_ANIMATION_MS = 180;
-const MS_PER_HOUR = 60 * 60 * 1000;
-const MS_PER_DAY = 24 * MS_PER_HOUR;
-
-type ClipboardCleanupRange = 'lastHour' | 'today' | 'last7Days' | 'last30Days' | 'olderThan30Days';
-type ClipboardHistoryFilter = 'all' | 'url' | 'text';
-
-const CLIPBOARD_HISTORY_FILTERS: ClipboardHistoryFilter[] = ['all', 'url', 'text'];
-const CLIPBOARD_HISTORY_FILTER_LABEL_KEYS: Record<ClipboardHistoryFilter, string> = {
-  all: 'clipboardHistoryTab.filters.all',
-  url: 'clipboardHistoryTab.filters.url',
-  text: 'clipboardHistoryTab.filters.text',
-};
-const CLIPBOARD_HISTORY_FILTER_DEFAULT_LABELS: Record<ClipboardHistoryFilter, string> = {
-  all: 'All',
-  url: 'URL',
-  text: 'Text',
-};
-
-function normalizeClipboardText(text: string): string {
-  return text.replace(/\r\n/g, '\n').trim();
-}
-
-function isLikelyUrl(text: string): boolean {
-  const value = text.trim();
-  if (/^https?:\/\/\S+$/i.test(value)) return true;
-  if (/^www\.[^\s]+\.[^\s]+$/i.test(value)) return true;
-  return /^[a-z0-9.-]+\.[a-z]{2,}(?:[/?#:]\S*)?$/i.test(value);
-}
-
-function isLikelyPassword(text: string): boolean {
-  const value = text.trim();
-  if (value.length < 8 || value.length > 128) return false;
-  if (/\s/.test(value) || isLikelyUrl(value) || /^\S+@\S+\.\S+$/.test(value)) return false;
-  const groups = [/[a-z]/, /[A-Z]/, /\d/, /[^a-zA-Z\d]/].filter((rule) => rule.test(value)).length;
-  return groups >= 3;
-}
-
-function isRecordableClipboardText(text: string): boolean {
-  return Boolean(text) && !isLikelyPassword(text);
-}
-
-function matchesClipboardFilter(item: ClipboardHistoryItem, filter: ClipboardHistoryFilter): boolean {
-  if (filter === 'all') return true;
-  const isUrl = isLikelyUrl(item.text);
-  if (filter === 'url') return isUrl;
-  return !isUrl && !isLikelyPassword(item.text);
-}
-
-function sanitizeHistory(data: unknown, historyLimit: number): ClipboardHistoryItem[] {
-  if (!Array.isArray(data)) return [];
-  return data
-    .map((item) => {
-      const row = item as Partial<ClipboardHistoryItem>;
-      const text = typeof row.text === 'string' ? normalizeClipboardText(row.text) : '';
-      if (!isRecordableClipboardText(text)) return null;
-      const createdAt = typeof row.createdAt === 'number' && Number.isFinite(row.createdAt) ? row.createdAt : Date.now();
-      const id = typeof row.id === 'number' && Number.isFinite(row.id) ? row.id : createdAt;
-      return { id, text, createdAt };
-    })
-    .filter((item): item is ClipboardHistoryItem => Boolean(item))
-    .slice(0, historyLimit);
-}
-
-function persistHistory(items: ClipboardHistoryItem[]): void {
-  try {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(items));
-  } catch {
-    // noop
-  }
-  window.api.storeWrite(STORE_KEY, items).catch(() => {});
-}
-
-function getPreviewText(text: string): string {
-  const oneLine = text.replace(/\s+/g, ' ').trim();
-  if (oneLine.length <= 72) return oneLine;
-  return `${oneLine.slice(0, 72)}…`;
-}
-
-function isSameLocalDay(left: Date, right: Date): boolean {
-  return left.getFullYear() === right.getFullYear()
-    && left.getMonth() === right.getMonth()
-    && left.getDate() === right.getDate();
-}
-
-function isItemInCleanupRange(item: ClipboardHistoryItem, range: ClipboardCleanupRange, now: number): boolean {
-  if (range === 'lastHour') return now - item.createdAt <= MS_PER_HOUR;
-  if (range === 'today') return isSameLocalDay(new Date(item.createdAt), new Date(now));
-  if (range === 'last7Days') return now - item.createdAt <= 7 * MS_PER_DAY;
-  if (range === 'last30Days') return now - item.createdAt <= 30 * MS_PER_DAY;
-  return now - item.createdAt > 30 * MS_PER_DAY;
-}
-
-function getClipboardHistoryExportFileName(now: Date): string {
-  const pad = (value: number): string => String(value).padStart(2, '0');
-  const date = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
-  const time = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  return `eIsland-clipboard-history-${date}-${time}.json`;
-}
-
-function buildClipboardHistoryExport(items: ClipboardHistoryItem[], exportedAt: Date): string {
-  return JSON.stringify({
-    app: 'eIsland',
-    type: 'clipboard-history',
-    exportedAt: exportedAt.toISOString(),
-    count: items.length,
-    items: items.map((item) => ({
-      id: item.id,
-      text: item.text,
-      createdAt: item.createdAt,
-      createdAtText: new Date(item.createdAt).toISOString(),
-    })),
-  }, null, 2);
-}
-
-function downloadTextFile(fileName: string, content: string): void {
-  const blob = new Blob([content], { type: 'application/json;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = fileName;
-  link.style.display = 'none';
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
+import { useClipboardHistoryFeedback } from '../hooks/useClipboardHistoryFeedback';
+import { useClipboardHistoryItems } from '../hooks/useClipboardHistoryItems';
+import { useClipboardHistorySelection } from '../hooks/useClipboardHistorySelection';
+import { buildClipboardHistoryExport, downloadTextFile, getClipboardHistoryExportFileName, matchesClipboardFilter } from '../utils/clipboardHistoryUtils';
+import { ClipboardHistoryBulkBar } from './ClipboardHistoryBulkBar';
+import { ClipboardHistoryHeader } from './ClipboardHistoryHeader';
+import { ClipboardHistoryItemRow } from './ClipboardHistoryItemRow';
 
 /**
- * 渲染最大展开态的剪贴板历史标签页
- * @returns 剪贴板历史标签页
+ * 剪贴板历史页主组件：hook 调用 → 组件组合。
  */
-export function ClipboardHistoryTab(): React.ReactElement {
+export function ClipboardHistoryTab(): ReactElement {
   const { t } = useTranslation();
-  const { setIdle, setLyrics } = useIslandStore();
-  const [items, setItems] = useState<ClipboardHistoryItem[]>([]);
-  const [historyEnabled, setHistoryEnabled] = useState<boolean>(true);
-  const [historyLimit, setHistoryLimit] = useState<number>(DEFAULT_HISTORY_LIMIT);
-  const [exitMaxExpandOnCopy, setExitMaxExpandOnCopy] = useState<boolean>(false);
-  const [copyFeedback, setCopyFeedback] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-  const [loaded, setLoaded] = useState(false);
-  const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [editText, setEditText] = useState('');
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
-  const [selectionMode, setSelectionMode] = useState(false);
-  const [selectionCollapsing, setSelectionCollapsing] = useState(false);
-  const [cleanupRange, setCleanupRange] = useState<ClipboardCleanupRange>('today');
-  const [activeFilter, setActiveFilter] = useState<ClipboardHistoryFilter>('all');
-  const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const copyFeedbackTimerRef = useRef<number | null>(null);
-  const selectionCollapseTimerRef = useRef<number | null>(null);
 
-  const adjustTextareaHeight = useCallback((el: HTMLTextAreaElement | null): void => {
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
-  }, []);
+  /* ── Hook: 反馈提示 ── */
+  const { copyFeedback, showCopyFeedback } = useClipboardHistoryFeedback();
 
-  useEffect(() => {
-    let cancelled = false;
+  /* ── Hook: 条目管理 ── */
+  const {
+    items, setItems, expandedId, setExpandedId,
+    editText, setEditText, editTextareaRef, adjustTextareaHeight,
+    handleToggleExpand, handleSaveEdit, handleCopy,
+  } = useClipboardHistoryItems(showCopyFeedback);
 
-    Promise.all([
-      window.api.storeRead(HISTORY_ENABLED_STORE_KEY),
-      window.api.storeRead(HISTORY_LIMIT_STORE_KEY),
-      window.api.storeRead(EXIT_MAX_EXPAND_ON_COPY_STORE_KEY),
-    ]).then(([enabledRaw, limitRaw, exitRaw]) => {
-      if (cancelled) return;
-      const nextEnabled = typeof enabledRaw === 'boolean' ? enabledRaw : true;
-      const nextLimit = typeof limitRaw === 'number' && Number.isFinite(limitRaw)
-        ? Math.max(1, Math.min(50, Math.round(limitRaw)))
-        : DEFAULT_HISTORY_LIMIT;
-      const nextExitOnCopy = typeof exitRaw === 'boolean' ? exitRaw : false;
-      setHistoryEnabled(nextEnabled);
-      setHistoryLimit(nextLimit);
-      setExitMaxExpandOnCopy(nextExitOnCopy);
-    }).catch(() => {
-      if (cancelled) return;
-      setHistoryEnabled(true);
-      setHistoryLimit(DEFAULT_HISTORY_LIMIT);
-      setExitMaxExpandOnCopy(false);
-    });
+  /* ── Hook: 选择模式 ── */
+  const {
+    selectedIds, selectionMode, selectionCollapsing, cleanupRange,
+    activeFilter, selectedCount, selectedIdSet, allSelected,
+    cleanupMatchedCount, handleToggleSelectionMode,
+    handleToggleSelect, handleToggleSelectAll,
+    handleCleanupRangeChange, handleFilterChange,
+    handleRemoveSelected, handleClearByRange,
+  } = useClipboardHistorySelection(items, setItems, expandedId, setExpandedId, setEditText);
 
-    window.api.storeRead(STORE_KEY).then((data) => {
-      if (cancelled) return;
-      if (Array.isArray(data) && data.length > 0) {
-        setItems(sanitizeHistory(data, DEFAULT_HISTORY_LIMIT));
-      } else {
-        try {
-          const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-          if (raw) {
-            const parsed = sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT);
-            setItems(parsed);
-            window.api.storeWrite(STORE_KEY, parsed).catch(() => {});
-          }
-        } catch {
-          // noop
-        }
-      }
-      setLoaded(true);
-    }).catch(() => {
-      try {
-        const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-        if (raw) setItems(sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT));
-      } catch {
-        // noop
-      }
-      if (!cancelled) setLoaded(true);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    setItems((prev) => prev.slice(0, historyLimit));
-  }, [historyLimit]);
-
-  useEffect(() => {
-    const itemIds = new Set(items.map((item) => item.id));
-    setSelectedIds((prev) => prev.filter((id) => itemIds.has(id)));
-  }, [items]);
-
-  useEffect(() => {
-    if (!loaded) return;
-    persistHistory(items);
-  }, [items, loaded]);
-
-  useEffect(() => {
-    if (!historyEnabled) return;
-    let timerId: number | null = null;
-    let disposed = false;
-    let lastText = '';
-
-    const poll = async (): Promise<void> => {
-      try {
-        const rawText = await window.api.clipboardReadText();
-        if (disposed) return;
-        const normalized = normalizeClipboardText(rawText);
-        if (!isRecordableClipboardText(normalized) || normalized === lastText) return;
-        lastText = normalized;
-        setItems((prev) => {
-          if (prev[0]?.text === normalized) return prev;
-          const now = Date.now();
-          const next: ClipboardHistoryItem = {
-            id: now,
-            text: normalized,
-            createdAt: now,
-          };
-          return [next, ...prev.filter((row) => row.text !== normalized)].slice(0, historyLimit);
-        });
-      } catch {
-        // noop
-      }
-    };
-
-    void poll();
-    timerId = window.setInterval(() => {
-      void poll();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      disposed = true;
-      if (timerId !== null) {
-        window.clearInterval(timerId);
-      }
-    };
-  }, [historyEnabled, historyLimit]);
-
-  const totalCount = items.length;
+  /* ── 筛选后可见条目 ── */
   const visibleItems = useMemo(
     () => items.filter((item) => matchesClipboardFilter(item, activeFilter)),
     [activeFilter, items],
   );
+  const totalCount = items.length;
   const visibleCount = visibleItems.length;
-  const selectedCount = selectedIds.length;
-  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
-  const visibleIdSet = useMemo(() => new Set(visibleItems.map((item) => item.id)), [visibleItems]);
-  const allSelected = visibleCount > 0 && visibleItems.every((item) => selectedIdSet.has(item.id));
-  const cleanupMatchedIdSet = useMemo(() => {
-    const now = Date.now();
-    return new Set(visibleItems.filter((item) => isItemInCleanupRange(item, cleanupRange, now)).map((item) => item.id));
-  }, [visibleItems, cleanupRange]);
-  const cleanupMatchedCount = cleanupMatchedIdSet.size;
-  const exportItems = useMemo(() => {
-    if (!selectionMode || selectedIds.length === 0) return visibleItems;
-    return visibleItems.filter((item) => selectedIdSet.has(item.id));
-  }, [selectedIdSet, selectedIds.length, selectionMode, visibleItems]);
-  const exportCount = exportItems.length;
 
+  /* ── 计数标签 ── */
   const countLabel = useMemo(
     () => activeFilter === 'all'
       ? t('clipboardHistoryTab.count', { defaultValue: '{{count}} 条', count: totalCount })
@@ -343,120 +81,30 @@ export function ClipboardHistoryTab(): React.ReactElement {
     [activeFilter, t, totalCount, visibleCount],
   );
 
-  const collapseSelectionMode = (): void => {
-    if (!selectionMode || selectionCollapsing) return;
-    setSelectionCollapsing(true);
-    if (selectionCollapseTimerRef.current !== null) {
-      window.clearTimeout(selectionCollapseTimerRef.current);
-    }
-    selectionCollapseTimerRef.current = window.setTimeout(() => {
-      setSelectionMode(false);
-      setSelectionCollapsing(false);
-      setSelectedIds([]);
-      selectionCollapseTimerRef.current = null;
-    }, SELECTION_COLLAPSE_ANIMATION_MS);
-  };
+  /* ── 导出范围 ── */
+  const exportItems = useMemo(() => {
+    if (!selectionMode || selectedIds.length === 0) return visibleItems;
+    return visibleItems.filter((item) => selectedIdSet.has(item.id));
+  }, [selectedIdSet, selectedIds.length, selectionMode, visibleItems]);
+  const exportCount = exportItems.length;
 
-  const handleToggleSelectionMode = (): void => {
-    if (selectionMode) {
-      collapseSelectionMode();
-      return;
-    }
-    if (selectionCollapseTimerRef.current !== null) {
-      window.clearTimeout(selectionCollapseTimerRef.current);
-      selectionCollapseTimerRef.current = null;
-    }
-    setSelectionCollapsing(false);
-    setSelectionMode(true);
-    setSelectedIds(Array.from(cleanupMatchedIdSet));
-  };
-
+  /* ── 清空全部 ── */
   const handleClear = (): void => {
     setItems([]);
-    setSelectedIds([]);
-    setSelectionMode(false);
-    setSelectionCollapsing(false);
-    if (selectionCollapseTimerRef.current !== null) {
-      window.clearTimeout(selectionCollapseTimerRef.current);
-      selectionCollapseTimerRef.current = null;
-    }
     setExpandedId(null);
     setEditText('');
   };
 
+  /* ── 删除单条 ── */
   const handleRemove = (id: number): void => {
     setItems((prev) => prev.filter((item) => item.id !== id));
-    setSelectedIds((prev) => prev.filter((selectedId) => selectedId !== id));
     if (expandedId === id) {
       setExpandedId(null);
       setEditText('');
     }
   };
 
-  const handleToggleSelect = (id: number): void => {
-    setSelectedIds((prev) => (
-      prev.includes(id)
-        ? prev.filter((selectedId) => selectedId !== id)
-        : [...prev, id]
-    ));
-  };
-
-  const handleToggleSelectAll = (): void => {
-    if (allSelected) {
-      setSelectedIds((prev) => prev.filter((id) => !visibleIdSet.has(id)));
-      return;
-    }
-    setSelectedIds((prev) => Array.from(new Set([
-      ...prev,
-      ...visibleItems.map((item) => item.id),
-    ])));
-  };
-
-  const handleCleanupRangeChange = (range: ClipboardCleanupRange): void => {
-    const now = Date.now();
-    setCleanupRange(range);
-    setSelectedIds(visibleItems.filter((item) => isItemInCleanupRange(item, range, now)).map((item) => item.id));
-  };
-
-  const handleFilterChange = (filter: ClipboardHistoryFilter): void => {
-    setActiveFilter(filter);
-    setSelectedIds([]);
-    if (expandedId !== null) {
-      const expandedItem = items.find((item) => item.id === expandedId);
-      if (expandedItem && !matchesClipboardFilter(expandedItem, filter)) {
-        setExpandedId(null);
-        setEditText('');
-      }
-    }
-  };
-
-  const handleRemoveSelected = (): void => {
-    if (selectedIds.length === 0) return;
-    const nextSelectedIds = new Set(selectedIds);
-    setItems((prev) => prev.filter((item) => !nextSelectedIds.has(item.id)));
-    setSelectedIds([]);
-    setSelectionMode(false);
-    setSelectionCollapsing(false);
-    if (expandedId !== null && nextSelectedIds.has(expandedId)) {
-      setExpandedId(null);
-      setEditText('');
-    }
-  };
-
-  const handleClearByRange = (): void => {
-    const now = Date.now();
-    const removedIds = new Set(items.filter((item) => isItemInCleanupRange(item, cleanupRange, now)).map((item) => item.id));
-    if (removedIds.size === 0) return;
-    setItems((prev) => prev.filter((item) => !removedIds.has(item.id)));
-    setSelectedIds((prev) => prev.filter((id) => !removedIds.has(id)));
-    setSelectionMode(false);
-    setSelectionCollapsing(false);
-    if (expandedId !== null && removedIds.has(expandedId)) {
-      setExpandedId(null);
-      setEditText('');
-    }
-  };
-
+  /* ── 导出 ── */
   const handleExport = (): void => {
     if (exportItems.length === 0) return;
     try {
@@ -474,167 +122,35 @@ export function ClipboardHistoryTab(): React.ReactElement {
     }
   };
 
-  const handleToggleExpand = (item: ClipboardHistoryItem): void => {
-    if (expandedId === item.id) {
-      setExpandedId(null);
-      setEditText('');
-      return;
-    }
-    setExpandedId(item.id);
-    setEditText(item.text);
-  };
-
-  const handleSaveEdit = (id: number): void => {
-    const nextText = editText.replace(/\r\n/g, '\n').trim();
-    if (!nextText) return;
-    setItems((prev) => prev.map((item) => (
-      item.id === id
-        ? { ...item, text: nextText }
-        : item
-    )));
-  };
-
-  const handleCopy = (item: ClipboardHistoryItem): void => {
-    const text = expandedId === item.id ? editText : item.text;
-    window.api.clipboardWriteText(text)
-      .then(() => {
-        showCopyFeedback('success', t('clipboardHistoryTab.messages.copySuccess', { defaultValue: '已复制到剪贴板' }));
-        if (exitMaxExpandOnCopy) {
-          const store = useIslandStore.getState();
-          if (store.isMusicPlaying) {
-            setLyrics();
-          } else {
-            setIdle(true);
-          }
-        }
-      })
-      .catch(() => {
-        showCopyFeedback('error', t('clipboardHistoryTab.messages.copyFailed', { defaultValue: '复制失败，请稍后重试' }));
-      });
-  };
-
-  useEffect(() => {
-    if (expandedId === null) return;
-    adjustTextareaHeight(editTextareaRef.current);
-  }, [editText, expandedId, adjustTextareaHeight]);
-
-  useEffect(() => () => {
-    if (copyFeedbackTimerRef.current !== null) {
-      window.clearTimeout(copyFeedbackTimerRef.current);
-    }
-    if (selectionCollapseTimerRef.current !== null) {
-      window.clearTimeout(selectionCollapseTimerRef.current);
-    }
-  }, []);
-
-  const showCopyFeedback = (type: 'success' | 'error', text: string): void => {
-    setCopyFeedback({ type, text });
-    if (copyFeedbackTimerRef.current !== null) {
-      window.clearTimeout(copyFeedbackTimerRef.current);
-    }
-    copyFeedbackTimerRef.current = window.setTimeout(() => {
-      setCopyFeedback(null);
-      copyFeedbackTimerRef.current = null;
-    }, 1800);
-  };
-
   return (
     <div className="clipboard-history">
-      <div className="clipboard-history-header">
-        <span className="clipboard-history-title">{t('clipboardHistoryTab.title', { defaultValue: '剪贴板历史' })}</span>
-        <div className="clipboard-history-header-right">
-          <span className="clipboard-history-count">{countLabel}</span>
-          <div className="clipboard-history-filter-bar" role="tablist" aria-label={t('clipboardHistoryTab.filters.aria', { defaultValue: '剪贴板类型筛选' })}>
-            {CLIPBOARD_HISTORY_FILTERS.map((filter) => (
-              <button
-                key={filter}
-                className={`clipboard-history-filter${activeFilter === filter ? ' clipboard-history-filter--active' : ''}`}
-                type="button"
-                role="tab"
-                aria-selected={activeFilter === filter}
-                onClick={() => handleFilterChange(filter)}
-              >
-                {t(CLIPBOARD_HISTORY_FILTER_LABEL_KEYS[filter], {
-                  defaultValue: CLIPBOARD_HISTORY_FILTER_DEFAULT_LABELS[filter],
-                })}
-              </button>
-            ))}
-          </div>
-          <button
-            className="clipboard-history-clear"
-            type="button"
-            onClick={handleClear}
-            disabled={totalCount === 0}
-          >
-            {t('clipboardHistoryTab.actions.clear', { defaultValue: '清空' })}
-          </button>
-          <button
-            className="clipboard-history-export"
-            type="button"
-            onClick={handleExport}
-            disabled={exportCount === 0}
-            title={selectionMode && selectedCount > 0
-              ? t('clipboardHistoryTab.actions.exportSelectedTitle', { defaultValue: '导出已选记录' })
-              : t('clipboardHistoryTab.actions.exportAllTitle', { defaultValue: '导出全部记录' })}
-          >
-            {t('clipboardHistoryTab.actions.export', { defaultValue: '导出' })}
-            {selectionMode && selectedCount > 0 ? ` (${selectedCount})` : ''}
-          </button>
-          <button
-            className={`clipboard-history-select-toggle${selectionMode ? ' clipboard-history-select-toggle--active' : ''}`}
-            type="button"
-            onClick={handleToggleSelectionMode}
-            disabled={totalCount === 0}
-          >
-            {selectionMode
-              ? t('clipboardHistoryTab.actions.cancelSelect', { defaultValue: '取消' })
-              : t('clipboardHistoryTab.actions.select', { defaultValue: '选择' })}
-          </button>
-        </div>
-      </div>
+      <ClipboardHistoryHeader
+        totalCount={totalCount}
+        visibleCount={visibleCount}
+        activeFilter={activeFilter}
+        exportCount={exportCount}
+        selectionMode={selectionMode}
+        selectedCount={selectedCount}
+        countLabel={countLabel}
+        onFilterChange={handleFilterChange}
+        onClear={handleClear}
+        onExport={handleExport}
+        onToggleSelectionMode={handleToggleSelectionMode}
+      />
 
       {selectionMode ? (
-        <div className={`clipboard-history-bulk-bar${selectionCollapsing ? ' clipboard-history-bulk-bar--collapsing' : ''}`}>
-          <label className="clipboard-history-select-all">
-            <input
-              type="checkbox"
-              checked={allSelected}
-              disabled={totalCount === 0}
-              onChange={handleToggleSelectAll}
-            />
-            <span>{t('clipboardHistoryTab.actions.selectAll', { defaultValue: '全选' })}</span>
-          </label>
-          <button
-            className="clipboard-history-bulk-delete"
-            type="button"
-            onClick={handleRemoveSelected}
-            disabled={selectedCount === 0}
-          >
-            {t('clipboardHistoryTab.actions.deleteSelected', { defaultValue: '删除已选' })}
-            {selectedCount > 0 ? ` (${selectedCount})` : ''}
-          </button>
-          <select
-            className="clipboard-history-range-select"
-            value={cleanupRange}
-            onChange={(e) => handleCleanupRangeChange(e.target.value as ClipboardCleanupRange)}
-            aria-label={t('clipboardHistoryTab.actions.rangeAria', { defaultValue: '选择清理时间范围' })}
-          >
-            <option value="lastHour">{t('clipboardHistoryTab.ranges.lastHour', { defaultValue: '最近 1 小时' })}</option>
-            <option value="today">{t('clipboardHistoryTab.ranges.today', { defaultValue: '今天' })}</option>
-            <option value="last7Days">{t('clipboardHistoryTab.ranges.last7Days', { defaultValue: '最近 7 天' })}</option>
-            <option value="last30Days">{t('clipboardHistoryTab.ranges.last30Days', { defaultValue: '最近 30 天' })}</option>
-            <option value="olderThan30Days">{t('clipboardHistoryTab.ranges.olderThan30Days', { defaultValue: '30 天前' })}</option>
-          </select>
-          <button
-            className="clipboard-history-range-clear"
-            type="button"
-            onClick={handleClearByRange}
-            disabled={cleanupMatchedCount === 0}
-          >
-            {t('clipboardHistoryTab.actions.clearRange', { defaultValue: '清理范围' })}
-            {cleanupMatchedCount > 0 ? ` (${cleanupMatchedCount})` : ''}
-          </button>
-        </div>
+        <ClipboardHistoryBulkBar
+          selectionCollapsing={selectionCollapsing}
+          allSelected={allSelected}
+          totalCount={totalCount}
+          selectedCount={selectedCount}
+          cleanupRange={cleanupRange}
+          cleanupMatchedCount={cleanupMatchedCount}
+          onToggleSelectAll={handleToggleSelectAll}
+          onRemoveSelected={handleRemoveSelected}
+          onCleanupRangeChange={handleCleanupRangeChange}
+          onClearByRange={handleClearByRange}
+        />
       ) : null}
 
       {copyFeedback ? (
@@ -657,87 +173,25 @@ export function ClipboardHistoryTab(): React.ReactElement {
           <div className="clipboard-history-empty">
             {t('clipboardHistoryTab.emptyFiltered', { defaultValue: '当前类型下没有记录。' })}
           </div>
-        ) : visibleItems.map((item) => {
-          const expanded = expandedId === item.id;
-          const selected = selectedIdSet.has(item.id);
-          return (
-            <div key={item.id} className={`clipboard-history-item${selectionMode && !selectionCollapsing && selected ? ' clipboard-history-item--selected' : ''}`}>
-              <div className={`clipboard-history-summary-row${selectionMode ? ' clipboard-history-summary-row--selecting' : ''}${selectionCollapsing ? ' clipboard-history-summary-row--collapsing' : ''}`}>
-                {selectionMode ? (
-                  <label className="clipboard-history-item-check">
-                    <input
-                      type="checkbox"
-                      checked={selected}
-                      onChange={() => handleToggleSelect(item.id)}
-                      aria-label={t('clipboardHistoryTab.actions.selectItemAria', { defaultValue: '选择该剪贴板记录' })}
-                    />
-                  </label>
-                ) : null}
-                <button
-                  className="clipboard-history-copy"
-                  type="button"
-                  onClick={() => handleCopy(item)}
-                  aria-label={t('clipboardHistoryTab.actions.copyAria', { defaultValue: '复制该记录到剪贴板' })}
-                  title={t('clipboardHistoryTab.actions.copyTitle', { defaultValue: '复制到剪贴板' })}
-                >
-                  <img src={SvgIcon.COPY} alt="" aria-hidden="true" />
-                </button>
-                <button
-                  className="clipboard-history-summary"
-                  type="button"
-                  onClick={() => handleToggleExpand(item)}
-                  title={item.text}
-                >
-                  <span className="clipboard-history-preview">{getPreviewText(item.text)}</span>
-                  <span className="clipboard-history-time">{new Date(item.createdAt).toLocaleString()}</span>
-                  <span className="clipboard-history-expand-indicator">
-                    {expanded
-                      ? t('clipboardHistoryTab.actions.collapse', { defaultValue: '收起' })
-                      : t('clipboardHistoryTab.actions.expand', { defaultValue: '展开' })}
-                  </span>
-                </button>
-              </div>
-
-              {expanded ? (
-                <div className="clipboard-history-detail">
-                  <textarea
-                    className="clipboard-history-content"
-                    value={editText}
-                    ref={editTextareaRef}
-                    onChange={(e) => {
-                      setEditText(e.target.value);
-                      adjustTextareaHeight(e.currentTarget);
-                    }}
-                    onKeyDown={(e) => {
-                      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                        e.preventDefault();
-                        handleSaveEdit(item.id);
-                      }
-                    }}
-                  />
-                  <div className="clipboard-history-actions">
-                    <button
-                      className="clipboard-history-save"
-                      type="button"
-                      onClick={() => handleSaveEdit(item.id)}
-                      disabled={!editText.trim()}
-                    >
-                      {t('clipboardHistoryTab.actions.save', { defaultValue: '保存' })}
-                    </button>
-                    <button
-                      className="clipboard-history-remove"
-                      type="button"
-                      onClick={() => handleRemove(item.id)}
-                      aria-label={t('clipboardHistoryTab.actions.removeAria', { defaultValue: '删除该剪贴板记录' })}
-                    >
-                      ×
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
+        ) : visibleItems.map((item) => (
+          <ClipboardHistoryItemRow
+            key={item.id}
+            item={item}
+            expanded={expandedId === item.id}
+            selected={selectedIdSet.has(item.id)}
+            selectionMode={selectionMode}
+            selectionCollapsing={selectionCollapsing}
+            editText={editText}
+            editTextareaRef={editTextareaRef}
+            onToggleSelect={handleToggleSelect}
+            onCopy={handleCopy}
+            onToggleExpand={handleToggleExpand}
+            onEditTextChange={setEditText}
+            onEditTextareaRef={adjustTextareaHeight}
+            onSaveEdit={handleSaveEdit}
+            onRemove={handleRemove}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/components/ClipboardHistoryTab.tsx
@@ -26,8 +26,8 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SvgIcon } from '../../../../utils/SvgIcon';
-import useIslandStore from '../../../../store/slices';
+import { SvgIcon } from '../../../../../../utils/SvgIcon';
+import useIslandStore from '../../../../../../store/slices';
 
 interface ClipboardHistoryItem {
   id: number;

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/config/clipboardHistoryConfig.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/config/clipboardHistoryConfig.ts
@@ -44,3 +44,5 @@ export const SELECTION_COLLAPSE_ANIMATION_MS = 180;
 export const MS_PER_HOUR = 60 * 60 * 1000;
 /** 毫秒/天 */
 export const MS_PER_DAY = 24 * MS_PER_HOUR;
+/** 反馈提示显示时长（ms） */
+export const FEEDBACK_DURATION_MS = 1800;

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/config/clipboardHistoryConfig.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/config/clipboardHistoryConfig.ts
@@ -1,0 +1,46 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file clipboardHistoryConfig.ts
+ * @description 剪贴板历史模块常量定义。
+ * @author 鸡哥
+ */
+
+/** 持久化键（store） */
+export const STORE_KEY = 'clipboard-history-recent';
+/** 持久化键（localStorage 兜底） */
+export const LOCAL_STORAGE_KEY = 'eIsland_clipboard_history_recent';
+/** 历史记录启用状态持久化键 */
+export const HISTORY_ENABLED_STORE_KEY = 'clipboard-history-enabled';
+/** 历史记录条数上限持久化键 */
+export const HISTORY_LIMIT_STORE_KEY = 'clipboard-history-limit';
+/** 复制后退出最大展开态持久化键 */
+export const EXIT_MAX_EXPAND_ON_COPY_STORE_KEY = 'clipboard-history-exit-max-expand-on-copy';
+/** 默认历史记录条数上限 */
+export const DEFAULT_HISTORY_LIMIT = 10;
+/** 剪贴板轮询间隔（ms） */
+export const POLL_INTERVAL_MS = 1000;
+/** 选择模式收起动画时长（ms） */
+export const SELECTION_COLLAPSE_ANIMATION_MS = 180;
+/** 毫秒/小时 */
+export const MS_PER_HOUR = 60 * 60 * 1000;
+/** 毫秒/天 */
+export const MS_PER_DAY = 24 * MS_PER_HOUR;

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryFeedback.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryFeedback.ts
@@ -25,10 +25,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { FEEDBACK_DURATION_MS } from '../config/clipboardHistoryConfig';
 import type { UseClipboardHistoryFeedbackReturn } from '../types/clipboardHistoryTypes';
-
-/** 反馈提示显示时长（ms） */
-const FEEDBACK_DURATION_MS = 1800;
 
 /**
  * 管理复制/导出等操作的反馈提示状态

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryFeedback.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryFeedback.ts
@@ -1,0 +1,58 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file useClipboardHistoryFeedback.ts
+ * @description 剪贴板历史反馈提示 hook。
+ * @author 鸡哥
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { UseClipboardHistoryFeedbackReturn } from '../types/clipboardHistoryTypes';
+
+/** 反馈提示显示时长（ms） */
+const FEEDBACK_DURATION_MS = 1800;
+
+/**
+ * 管理复制/导出等操作的反馈提示状态
+ */
+export function useClipboardHistoryFeedback(): UseClipboardHistoryFeedbackReturn {
+  const [copyFeedback, setCopyFeedback] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const copyFeedbackTimerRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current);
+    }
+  }, []);
+
+  const showCopyFeedback = useCallback((type: 'success' | 'error', text: string): void => {
+    setCopyFeedback({ type, text });
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current);
+    }
+    copyFeedbackTimerRef.current = window.setTimeout(() => {
+      setCopyFeedback(null);
+      copyFeedbackTimerRef.current = null;
+    }, FEEDBACK_DURATION_MS);
+  }, []);
+
+  return { copyFeedback, showCopyFeedback };
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
@@ -187,8 +187,8 @@ export function useClipboardHistoryItems(
 
   /* ── 保存编辑 ── */
   const handleSaveEdit = useCallback((id: number): void => {
-    const nextText = editText.replace(/\r\n/g, '\n').trim();
-    if (!nextText) return;
+    const nextText = editText.replace(/\r\n/g, '\n');
+    if (!nextText.trim()) return;
     setItems((prev) => prev.map((item) => (
       item.id === id
         ? { ...item, text: nextText }

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
@@ -1,0 +1,222 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file useClipboardHistoryItems.ts
+ * @description 剪贴板历史条目管理 hook — 初始化加载、轮询采集、持久化、展开/编辑、复制。
+ * @author 鸡哥
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import useIslandStore from '../../../../../../store/slices';
+import { DEFAULT_HISTORY_LIMIT, EXIT_MAX_EXPAND_ON_COPY_STORE_KEY, HISTORY_ENABLED_STORE_KEY, HISTORY_LIMIT_STORE_KEY, LOCAL_STORAGE_KEY, POLL_INTERVAL_MS, STORE_KEY } from '../config/clipboardHistoryConfig';
+import type { ClipboardHistoryItem, UseClipboardHistoryItemsReturn } from '../types/clipboardHistoryTypes';
+import { isRecordableClipboardText, normalizeClipboardText, persistHistory, sanitizeHistory } from '../utils/clipboardHistoryUtils';
+
+/**
+ * 管理剪贴板历史条目的完整生命周期：加载、轮询、持久化、展开/编辑、复制
+ * @param showCopyFeedback - 复制结果反馈回调
+ */
+export function useClipboardHistoryItems(
+  showCopyFeedback: (type: 'success' | 'error', text: string) => void,
+): UseClipboardHistoryItemsReturn {
+  const { t } = useTranslation();
+  const { setIdle, setLyrics } = useIslandStore();
+  const [items, setItems] = useState<ClipboardHistoryItem[]>([]);
+  const [historyEnabled, setHistoryEnabled] = useState<boolean>(true);
+  const [historyLimit, setHistoryLimit] = useState<number>(DEFAULT_HISTORY_LIMIT);
+  const [exitMaxExpandOnCopy, setExitMaxExpandOnCopy] = useState<boolean>(false);
+  const [loaded, setLoaded] = useState(false);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [editText, setEditText] = useState('');
+  const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const adjustTextareaHeight = useCallback((el: HTMLTextAreaElement | null): void => {
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  /* ── 初始化加载设置与历史数据 ── */
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([
+      window.api.storeRead(HISTORY_ENABLED_STORE_KEY),
+      window.api.storeRead(HISTORY_LIMIT_STORE_KEY),
+      window.api.storeRead(EXIT_MAX_EXPAND_ON_COPY_STORE_KEY),
+    ]).then(([enabledRaw, limitRaw, exitRaw]) => {
+      if (cancelled) return;
+      const nextEnabled = typeof enabledRaw === 'boolean' ? enabledRaw : true;
+      const nextLimit = typeof limitRaw === 'number' && Number.isFinite(limitRaw)
+        ? Math.max(1, Math.min(50, Math.round(limitRaw)))
+        : DEFAULT_HISTORY_LIMIT;
+      const nextExitOnCopy = typeof exitRaw === 'boolean' ? exitRaw : false;
+      setHistoryEnabled(nextEnabled);
+      setHistoryLimit(nextLimit);
+      setExitMaxExpandOnCopy(nextExitOnCopy);
+    }).catch(() => {
+      if (cancelled) return;
+      setHistoryEnabled(true);
+      setHistoryLimit(DEFAULT_HISTORY_LIMIT);
+      setExitMaxExpandOnCopy(false);
+    });
+
+    window.api.storeRead(STORE_KEY).then((data) => {
+      if (cancelled) return;
+      if (Array.isArray(data) && data.length > 0) {
+        setItems(sanitizeHistory(data, DEFAULT_HISTORY_LIMIT));
+      } else {
+        try {
+          const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+          if (raw) {
+            const parsed = sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT);
+            setItems(parsed);
+            window.api.storeWrite(STORE_KEY, parsed).catch(() => {});
+          }
+        } catch {
+          // noop
+        }
+      }
+      setLoaded(true);
+    }).catch(() => {
+      try {
+        const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (raw) setItems(sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT));
+      } catch {
+        // noop
+      }
+      if (!cancelled) setLoaded(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /* ── 条数上限变化时截断 ── */
+  useEffect(() => {
+    setItems((prev) => prev.slice(0, historyLimit));
+  }, [historyLimit]);
+
+  /* ── 持久化 ── */
+  useEffect(() => {
+    if (!loaded) return;
+    persistHistory(items);
+  }, [items, loaded]);
+
+  /* ── 剪贴板轮询采集 ── */
+  useEffect(() => {
+    if (!historyEnabled) return;
+    let timerId: number | null = null;
+    let disposed = false;
+    let lastText = '';
+
+    const poll = async (): Promise<void> => {
+      try {
+        const rawText = await window.api.clipboardReadText();
+        if (disposed) return;
+        const normalized = normalizeClipboardText(rawText);
+        if (!isRecordableClipboardText(normalized) || normalized === lastText) return;
+        lastText = normalized;
+        setItems((prev) => {
+          if (prev[0]?.text === normalized) return prev;
+          const now = Date.now();
+          const next: ClipboardHistoryItem = {
+            id: now,
+            text: normalized,
+            createdAt: now,
+          };
+          return [next, ...prev.filter((row) => row.text !== normalized)].slice(0, historyLimit);
+        });
+      } catch {
+        // noop
+      }
+    };
+
+    void poll();
+    timerId = window.setInterval(() => {
+      void poll();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      disposed = true;
+      if (timerId !== null) {
+        window.clearInterval(timerId);
+      }
+    };
+  }, [historyEnabled, historyLimit]);
+
+  /* ── 展开/编辑 textarea 自适应高度 ── */
+  useEffect(() => {
+    if (expandedId === null) return;
+    adjustTextareaHeight(editTextareaRef.current);
+  }, [editText, expandedId, adjustTextareaHeight]);
+
+  /* ── 展开/折叠切换 ── */
+  const handleToggleExpand = useCallback((item: ClipboardHistoryItem): void => {
+    if (expandedId === item.id) {
+      setExpandedId(null);
+      setEditText('');
+      return;
+    }
+    setExpandedId(item.id);
+    setEditText(item.text);
+  }, [expandedId]);
+
+  /* ── 保存编辑 ── */
+  const handleSaveEdit = useCallback((id: number): void => {
+    const nextText = editText.replace(/\r\n/g, '\n').trim();
+    if (!nextText) return;
+    setItems((prev) => prev.map((item) => (
+      item.id === id
+        ? { ...item, text: nextText }
+        : item
+    )));
+  }, [editText]);
+
+  /* ── 复制到剪贴板 ── */
+  const handleCopy = useCallback((item: ClipboardHistoryItem): void => {
+    const text = expandedId === item.id ? editText : item.text;
+    window.api.clipboardWriteText(text)
+      .then(() => {
+        showCopyFeedback('success', t('clipboardHistoryTab.messages.copySuccess', { defaultValue: '已复制到剪贴板' }));
+        if (exitMaxExpandOnCopy) {
+          const store = useIslandStore.getState();
+          if (store.isMusicPlaying) {
+            setLyrics();
+          } else {
+            setIdle(true);
+          }
+        }
+      })
+      .catch(() => {
+        showCopyFeedback('error', t('clipboardHistoryTab.messages.copyFailed', { defaultValue: '复制失败，请稍后重试' }));
+      });
+  }, [expandedId, editText, exitMaxExpandOnCopy, showCopyFeedback, t, setIdle, setLyrics]);
+
+  return {
+    items, setItems, historyLimit, loaded,
+    expandedId, setExpandedId, editText, setEditText,
+    editTextareaRef, adjustTextareaHeight,
+    handleToggleExpand, handleSaveEdit, handleCopy,
+  };
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistoryItems.ts
@@ -59,6 +59,7 @@ export function useClipboardHistoryItems(
   useEffect(() => {
     let cancelled = false;
 
+    /* 先读取设置，再用解析后的 historyLimit 加载历史数据 */
     Promise.all([
       window.api.storeRead(HISTORY_ENABLED_STORE_KEY),
       window.api.storeRead(HISTORY_LIMIT_STORE_KEY),
@@ -73,38 +74,40 @@ export function useClipboardHistoryItems(
       setHistoryEnabled(nextEnabled);
       setHistoryLimit(nextLimit);
       setExitMaxExpandOnCopy(nextExitOnCopy);
+      return nextLimit;
+    }).then((resolvedLimit) => {
+      if (cancelled) return;
+      return window.api.storeRead(STORE_KEY).then((data) => {
+        if (cancelled) return;
+        const limit = resolvedLimit ?? DEFAULT_HISTORY_LIMIT;
+        if (Array.isArray(data) && data.length > 0) {
+          setItems(sanitizeHistory(data, limit));
+        } else {
+          try {
+            const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+            if (raw) {
+              const parsed = sanitizeHistory(JSON.parse(raw) as unknown[], limit);
+              setItems(parsed);
+              window.api.storeWrite(STORE_KEY, parsed).catch(() => {});
+            }
+          } catch {
+            // noop
+          }
+        }
+        setLoaded(true);
+      });
     }).catch(() => {
       if (cancelled) return;
       setHistoryEnabled(true);
       setHistoryLimit(DEFAULT_HISTORY_LIMIT);
       setExitMaxExpandOnCopy(false);
-    });
-
-    window.api.storeRead(STORE_KEY).then((data) => {
-      if (cancelled) return;
-      if (Array.isArray(data) && data.length > 0) {
-        setItems(sanitizeHistory(data, DEFAULT_HISTORY_LIMIT));
-      } else {
-        try {
-          const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-          if (raw) {
-            const parsed = sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT);
-            setItems(parsed);
-            window.api.storeWrite(STORE_KEY, parsed).catch(() => {});
-          }
-        } catch {
-          // noop
-        }
-      }
-      setLoaded(true);
-    }).catch(() => {
       try {
         const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
         if (raw) setItems(sanitizeHistory(JSON.parse(raw) as unknown[], DEFAULT_HISTORY_LIMIT));
       } catch {
         // noop
       }
-      if (!cancelled) setLoaded(true);
+      setLoaded(true);
     });
 
     return () => {

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistorySelection.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistorySelection.ts
@@ -1,0 +1,195 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file useClipboardHistorySelection.ts
+ * @description 剪贴板历史选择模式与批量操作 hook。
+ * @author 鸡哥
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SELECTION_COLLAPSE_ANIMATION_MS } from '../config/clipboardHistoryConfig';
+import type { ClipboardCleanupRange, ClipboardHistoryFilter, ClipboardHistoryItem, UseClipboardHistorySelectionReturn } from '../types/clipboardHistoryTypes';
+import { isItemInCleanupRange, matchesClipboardFilter } from '../utils/clipboardHistoryUtils';
+
+/**
+ * 管理选择模式、多选状态、筛选、批量删除/清理
+ * @param items - 全部条目
+ * @param setItems - 条目 setter
+ * @param expandedId - 当前展开条目 ID
+ * @param setExpandedId - 展开条目 setter
+ * @param setEditText - 编辑文本 setter
+ */
+export function useClipboardHistorySelection(
+  items: ClipboardHistoryItem[],
+  setItems: React.Dispatch<React.SetStateAction<ClipboardHistoryItem[]>>,
+  expandedId: number | null,
+  setExpandedId: React.Dispatch<React.SetStateAction<number | null>>,
+  setEditText: React.Dispatch<React.SetStateAction<string>>,
+): UseClipboardHistorySelectionReturn {
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectionCollapsing, setSelectionCollapsing] = useState(false);
+  const [cleanupRange, setCleanupRange] = useState<ClipboardCleanupRange>('today');
+  const [activeFilter, setActiveFilter] = useState<ClipboardHistoryFilter>('all');
+  const selectionCollapseTimerRef = useRef<number | null>(null);
+
+  /* ── 筛选后可见条目 ── */
+  const visibleItems = useMemo(
+    () => items.filter((item) => matchesClipboardFilter(item, activeFilter)),
+    [activeFilter, items],
+  );
+
+  /* ── 条目变化时清理已失效的选中 ID ── */
+  useEffect(() => {
+    const itemIds = new Set(items.map((item) => item.id));
+    setSelectedIds((prev) => prev.filter((id) => itemIds.has(id)));
+  }, [items]);
+
+  /* ── 组件卸载时清理定时器 ── */
+  useEffect(() => () => {
+    if (selectionCollapseTimerRef.current !== null) {
+      window.clearTimeout(selectionCollapseTimerRef.current);
+    }
+  }, []);
+
+  /* ── 计算属性 ── */
+  const selectedCount = selectedIds.length;
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const visibleIdSet = useMemo(() => new Set(visibleItems.map((item) => item.id)), [visibleItems]);
+  const visibleCount = visibleItems.length;
+  const allSelected = visibleCount > 0 && visibleItems.every((item) => selectedIdSet.has(item.id));
+  const cleanupMatchedIdSet = useMemo(() => {
+    const now = Date.now();
+    return new Set(visibleItems.filter((item) => isItemInCleanupRange(item, cleanupRange, now)).map((item) => item.id));
+  }, [visibleItems, cleanupRange]);
+  const cleanupMatchedCount = cleanupMatchedIdSet.size;
+
+  /* ── 收起选择模式（带动画） ── */
+  const collapseSelectionMode = useCallback((): void => {
+    if (!selectionMode || selectionCollapsing) return;
+    setSelectionCollapsing(true);
+    if (selectionCollapseTimerRef.current !== null) {
+      window.clearTimeout(selectionCollapseTimerRef.current);
+    }
+    selectionCollapseTimerRef.current = window.setTimeout(() => {
+      setSelectionMode(false);
+      setSelectionCollapsing(false);
+      setSelectedIds([]);
+      selectionCollapseTimerRef.current = null;
+    }, SELECTION_COLLAPSE_ANIMATION_MS);
+  }, [selectionMode, selectionCollapsing]);
+
+  /* ── 切换选择模式 ── */
+  const handleToggleSelectionMode = useCallback((): void => {
+    if (selectionMode) {
+      collapseSelectionMode();
+      return;
+    }
+    if (selectionCollapseTimerRef.current !== null) {
+      window.clearTimeout(selectionCollapseTimerRef.current);
+      selectionCollapseTimerRef.current = null;
+    }
+    setSelectionCollapsing(false);
+    setSelectionMode(true);
+    setSelectedIds(Array.from(cleanupMatchedIdSet));
+  }, [selectionMode, collapseSelectionMode, cleanupMatchedIdSet]);
+
+  /* ── 单条勾选/取消 ── */
+  const handleToggleSelect = useCallback((id: number): void => {
+    setSelectedIds((prev) => (
+      prev.includes(id)
+        ? prev.filter((selectedId) => selectedId !== id)
+        : [...prev, id]
+    ));
+  }, []);
+
+  /* ── 全选/取消全选（当前筛选范围内） ── */
+  const handleToggleSelectAll = useCallback((): void => {
+    if (allSelected) {
+      setSelectedIds((prev) => prev.filter((id) => !visibleIdSet.has(id)));
+      return;
+    }
+    setSelectedIds((prev) => Array.from(new Set([
+      ...prev,
+      ...visibleItems.map((item) => item.id),
+    ])));
+  }, [allSelected, visibleIdSet, visibleItems]);
+
+  /* ── 清理范围变化 ── */
+  const handleCleanupRangeChange = useCallback((range: ClipboardCleanupRange): void => {
+    const now = Date.now();
+    setCleanupRange(range);
+    setSelectedIds(visibleItems.filter((item) => isItemInCleanupRange(item, range, now)).map((item) => item.id));
+  }, [visibleItems]);
+
+  /* ── 筛选类型变化 ── */
+  const handleFilterChange = useCallback((filter: ClipboardHistoryFilter): void => {
+    setActiveFilter(filter);
+    setSelectedIds([]);
+    if (expandedId !== null) {
+      const expandedItem = items.find((item) => item.id === expandedId);
+      if (expandedItem && !matchesClipboardFilter(expandedItem, filter)) {
+        setExpandedId(null);
+        setEditText('');
+      }
+    }
+  }, [expandedId, items, setExpandedId, setEditText]);
+
+  /* ── 删除已选条目 ── */
+  const handleRemoveSelected = useCallback((): void => {
+    if (selectedIds.length === 0) return;
+    const nextSelectedIds = new Set(selectedIds);
+    setItems((prev) => prev.filter((item) => !nextSelectedIds.has(item.id)));
+    setSelectedIds([]);
+    setSelectionMode(false);
+    setSelectionCollapsing(false);
+    if (expandedId !== null && nextSelectedIds.has(expandedId)) {
+      setExpandedId(null);
+      setEditText('');
+    }
+  }, [selectedIds, expandedId, setItems, setExpandedId, setEditText]);
+
+  /* ── 按时间范围清理 ── */
+  const handleClearByRange = useCallback((): void => {
+    const now = Date.now();
+    const removedIds = new Set(items.filter((item) => isItemInCleanupRange(item, cleanupRange, now)).map((item) => item.id));
+    if (removedIds.size === 0) return;
+    setItems((prev) => prev.filter((item) => !removedIds.has(item.id)));
+    setSelectedIds((prev) => prev.filter((id) => !removedIds.has(id)));
+    setSelectionMode(false);
+    setSelectionCollapsing(false);
+    if (expandedId !== null && removedIds.has(expandedId)) {
+      setExpandedId(null);
+      setEditText('');
+    }
+  }, [items, cleanupRange, expandedId, setItems, setExpandedId, setEditText]);
+
+  return {
+    selectedIds, setSelectedIds, selectionMode, setSelectionMode,
+    selectionCollapsing, setSelectionCollapsing, cleanupRange,
+    activeFilter, setActiveFilter,
+    selectedCount, selectedIdSet, visibleIdSet, allSelected,
+    cleanupMatchedIdSet, cleanupMatchedCount,
+    handleToggleSelectionMode, handleToggleSelect, handleToggleSelectAll,
+    handleCleanupRangeChange, handleFilterChange,
+    handleRemoveSelected, handleClearByRange,
+  };
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistorySelection.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/hooks/useClipboardHistorySelection.ts
@@ -186,7 +186,7 @@ export function useClipboardHistorySelection(
     selectedIds, setSelectedIds, selectionMode, setSelectionMode,
     selectionCollapsing, setSelectionCollapsing, cleanupRange,
     activeFilter, setActiveFilter,
-    selectedCount, selectedIdSet, visibleIdSet, allSelected,
+    selectedCount, selectedIdSet, visibleItems, visibleIdSet, allSelected,
     cleanupMatchedIdSet, cleanupMatchedCount,
     handleToggleSelectionMode, handleToggleSelect, handleToggleSelectAll,
     handleCleanupRangeChange, handleFilterChange,

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/index.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/index.ts
@@ -1,0 +1,27 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file index.ts
+ * @description 剪贴板历史模块统一导出入口。
+ * @author 鸡哥
+ */
+
+export { ClipboardHistoryTab } from './components/ClipboardHistoryTab';

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/types/clipboardHistoryTypes.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/types/clipboardHistoryTypes.ts
@@ -131,6 +131,7 @@ export interface UseClipboardHistorySelectionReturn {
   setActiveFilter: React.Dispatch<React.SetStateAction<ClipboardHistoryFilter>>;
   selectedCount: number;
   selectedIdSet: Set<number>;
+  visibleItems: ClipboardHistoryItem[];
   visibleIdSet: Set<number>;
   allSelected: boolean;
   cleanupMatchedIdSet: Set<number>;

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/types/clipboardHistoryTypes.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/types/clipboardHistoryTypes.ts
@@ -1,0 +1,151 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file clipboardHistoryTypes.ts
+ * @description 剪贴板历史模块类型定义。
+ * @author 鸡哥
+ */
+
+/** 剪贴板历史条目 */
+export interface ClipboardHistoryItem {
+  id: number;
+  text: string;
+  createdAt: number;
+}
+
+/** 清理时间范围 */
+export type ClipboardCleanupRange = 'lastHour' | 'today' | 'last7Days' | 'last30Days' | 'olderThan30Days';
+
+/** 筛选类型 */
+export type ClipboardHistoryFilter = 'all' | 'url' | 'text';
+
+/** 筛选选项列表 */
+export const CLIPBOARD_HISTORY_FILTERS: ClipboardHistoryFilter[] = ['all', 'url', 'text'];
+
+/** 筛选选项翻译键 */
+export const CLIPBOARD_HISTORY_FILTER_LABEL_KEYS: Record<ClipboardHistoryFilter, string> = {
+  all: 'clipboardHistoryTab.filters.all',
+  url: 'clipboardHistoryTab.filters.url',
+  text: 'clipboardHistoryTab.filters.text',
+};
+
+/** 筛选选项默认标签 */
+export const CLIPBOARD_HISTORY_FILTER_DEFAULT_LABELS: Record<ClipboardHistoryFilter, string> = {
+  all: 'All',
+  url: 'URL',
+  text: 'Text',
+};
+
+/** ClipboardHistoryHeader 组件入参 */
+export interface ClipboardHistoryHeaderProps {
+  totalCount: number;
+  visibleCount: number;
+  activeFilter: ClipboardHistoryFilter;
+  exportCount: number;
+  selectionMode: boolean;
+  selectedCount: number;
+  countLabel: string;
+  onFilterChange: (filter: ClipboardHistoryFilter) => void;
+  onClear: () => void;
+  onExport: () => void;
+  onToggleSelectionMode: () => void;
+}
+
+/** ClipboardHistoryBulkBar 组件入参 */
+export interface ClipboardHistoryBulkBarProps {
+  selectionCollapsing: boolean;
+  allSelected: boolean;
+  totalCount: number;
+  selectedCount: number;
+  cleanupRange: ClipboardCleanupRange;
+  cleanupMatchedCount: number;
+  onToggleSelectAll: () => void;
+  onRemoveSelected: () => void;
+  onCleanupRangeChange: (range: ClipboardCleanupRange) => void;
+  onClearByRange: () => void;
+}
+
+/** ClipboardHistoryItemRow 组件入参 */
+export interface ClipboardHistoryItemRowProps {
+  item: ClipboardHistoryItem;
+  expanded: boolean;
+  selected: boolean;
+  selectionMode: boolean;
+  selectionCollapsing: boolean;
+  editText: string;
+  editTextareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  onToggleSelect: (id: number) => void;
+  onCopy: (item: ClipboardHistoryItem) => void;
+  onToggleExpand: (item: ClipboardHistoryItem) => void;
+  onEditTextChange: (text: string) => void;
+  onEditTextareaRef: (el: HTMLTextAreaElement | null) => void;
+  onSaveEdit: (id: number) => void;
+  onRemove: (id: number) => void;
+}
+
+/** useClipboardHistoryItems 返回值类型 */
+export interface UseClipboardHistoryItemsReturn {
+  items: ClipboardHistoryItem[];
+  setItems: React.Dispatch<React.SetStateAction<ClipboardHistoryItem[]>>;
+  historyLimit: number;
+  loaded: boolean;
+  expandedId: number | null;
+  setExpandedId: React.Dispatch<React.SetStateAction<number | null>>;
+  editText: string;
+  setEditText: React.Dispatch<React.SetStateAction<string>>;
+  editTextareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  adjustTextareaHeight: (el: HTMLTextAreaElement | null) => void;
+  handleToggleExpand: (item: ClipboardHistoryItem) => void;
+  handleSaveEdit: (id: number) => void;
+  handleCopy: (item: ClipboardHistoryItem) => void;
+}
+
+/** useClipboardHistorySelection 返回值类型 */
+export interface UseClipboardHistorySelectionReturn {
+  selectedIds: number[];
+  setSelectedIds: React.Dispatch<React.SetStateAction<number[]>>;
+  selectionMode: boolean;
+  setSelectionMode: React.Dispatch<React.SetStateAction<boolean>>;
+  selectionCollapsing: boolean;
+  setSelectionCollapsing: React.Dispatch<React.SetStateAction<boolean>>;
+  cleanupRange: ClipboardCleanupRange;
+  activeFilter: ClipboardHistoryFilter;
+  setActiveFilter: React.Dispatch<React.SetStateAction<ClipboardHistoryFilter>>;
+  selectedCount: number;
+  selectedIdSet: Set<number>;
+  visibleIdSet: Set<number>;
+  allSelected: boolean;
+  cleanupMatchedIdSet: Set<number>;
+  cleanupMatchedCount: number;
+  handleToggleSelectionMode: () => void;
+  handleToggleSelect: (id: number) => void;
+  handleToggleSelectAll: () => void;
+  handleCleanupRangeChange: (range: ClipboardCleanupRange) => void;
+  handleFilterChange: (filter: ClipboardHistoryFilter) => void;
+  handleRemoveSelected: () => void;
+  handleClearByRange: () => void;
+}
+
+/** useClipboardHistoryFeedback 返回值类型 */
+export interface UseClipboardHistoryFeedbackReturn {
+  copyFeedback: { type: 'success' | 'error'; text: string } | null;
+  showCopyFeedback: (type: 'success' | 'error', text: string) => void;
+}

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/utils/clipboardHistoryUtils.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/utils/clipboardHistoryUtils.ts
@@ -40,13 +40,25 @@ export function isLikelyUrl(text: string): boolean {
   return /^[a-z0-9.-]+\.[a-z]{2,}(?:[/?#:]\S*)?$/i.test(value);
 }
 
-/** 判断文本是否可能是密码（不应记录） */
+/** 判断文本是否可能是密码或令牌（不应记录） */
 export function isLikelyPassword(text: string): boolean {
   const value = text.trim();
-  if (value.length < 8 || value.length > 128) return false;
-  if (/\s/.test(value) || isLikelyUrl(value) || /^\S+@\S+\.\S+$/.test(value)) return false;
+  if (!value) return false;
+  if (isLikelyUrl(value) || /^\S+@\S+\.\S+$/.test(value)) return false;
+
+  const len = value.length;
+
+  /* JWT：三段 base64url */
+  if (/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value)) return true;
+
+  /* 长随机令牌（hex / base64 / url-safe） */
+  if (len >= 32 && /^[A-Za-z0-9+/=_-]+$/.test(value)) return true;
+
+  /* 常规密码规则 */
+  if (len < 8 || len > 128) return false;
+  if (/\s/.test(value)) return false;
   const groups = [/[a-z]/, /[A-Z]/, /\d/, /[^a-zA-Z\d]/].filter((rule) => rule.test(value)).length;
-  return groups >= 3;
+  return groups >= 3 || (len >= 12 && groups >= 2);
 }
 
 /** 判断文本是否应该被记录 */

--- a/src/renderer/components/states/maxExpand/components/clipBoardHistory/utils/clipboardHistoryUtils.ts
+++ b/src/renderer/components/states/maxExpand/components/clipBoardHistory/utils/clipboardHistoryUtils.ts
@@ -1,0 +1,150 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file clipboardHistoryUtils.ts
+ * @description 剪贴板历史模块纯工具函数。
+ * @author 鸡哥
+ */
+
+import { LOCAL_STORAGE_KEY, MS_PER_DAY, MS_PER_HOUR, STORE_KEY } from '../config/clipboardHistoryConfig';
+import type { ClipboardCleanupRange, ClipboardHistoryFilter, ClipboardHistoryItem } from '../types/clipboardHistoryTypes';
+
+/** 标准化剪贴板文本（统一换行符、去首尾空白） */
+export function normalizeClipboardText(text: string): string {
+  return text.replace(/\r\n/g, '\n').trim();
+}
+
+/** 判断文本是否可能是 URL */
+export function isLikelyUrl(text: string): boolean {
+  const value = text.trim();
+  if (/^https?:\/\/\S+$/i.test(value)) return true;
+  if (/^www\.[^\s]+\.[^\s]+$/i.test(value)) return true;
+  return /^[a-z0-9.-]+\.[a-z]{2,}(?:[/?#:]\S*)?$/i.test(value);
+}
+
+/** 判断文本是否可能是密码（不应记录） */
+export function isLikelyPassword(text: string): boolean {
+  const value = text.trim();
+  if (value.length < 8 || value.length > 128) return false;
+  if (/\s/.test(value) || isLikelyUrl(value) || /^\S+@\S+\.\S+$/.test(value)) return false;
+  const groups = [/[a-z]/, /[A-Z]/, /\d/, /[^a-zA-Z\d]/].filter((rule) => rule.test(value)).length;
+  return groups >= 3;
+}
+
+/** 判断文本是否应该被记录 */
+export function isRecordableClipboardText(text: string): boolean {
+  return Boolean(text) && !isLikelyPassword(text);
+}
+
+/** 根据筛选条件匹配条目 */
+export function matchesClipboardFilter(item: ClipboardHistoryItem, filter: ClipboardHistoryFilter): boolean {
+  if (filter === 'all') return true;
+  const isUrl = isLikelyUrl(item.text);
+  if (filter === 'url') return isUrl;
+  return !isUrl && !isLikelyPassword(item.text);
+}
+
+/** 校验并截断历史数据 */
+export function sanitizeHistory(data: unknown, historyLimit: number): ClipboardHistoryItem[] {
+  if (!Array.isArray(data)) return [];
+  return data
+    .map((item) => {
+      const row = item as Partial<ClipboardHistoryItem>;
+      const text = typeof row.text === 'string' ? normalizeClipboardText(row.text) : '';
+      if (!isRecordableClipboardText(text)) return null;
+      const createdAt = typeof row.createdAt === 'number' && Number.isFinite(row.createdAt) ? row.createdAt : Date.now();
+      const id = typeof row.id === 'number' && Number.isFinite(row.id) ? row.id : createdAt;
+      return { id, text, createdAt };
+    })
+    .filter((item): item is ClipboardHistoryItem => Boolean(item))
+    .slice(0, historyLimit);
+}
+
+/** 持久化历史数据（store + localStorage 兜底） */
+export function persistHistory(items: ClipboardHistoryItem[]): void {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // noop
+  }
+  window.api.storeWrite(STORE_KEY, items).catch(() => {});
+}
+
+/** 获取预览文本（单行、截断） */
+export function getPreviewText(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= 72) return oneLine;
+  return `${oneLine.slice(0, 72)}…`;
+}
+
+/** 判断两个时间戳是否在同一天（本地时间） */
+export function isSameLocalDay(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear()
+    && left.getMonth() === right.getMonth()
+    && left.getDate() === right.getDate();
+}
+
+/** 判断条目是否在清理时间范围内 */
+export function isItemInCleanupRange(item: ClipboardHistoryItem, range: ClipboardCleanupRange, now: number): boolean {
+  if (range === 'lastHour') return now - item.createdAt <= MS_PER_HOUR;
+  if (range === 'today') return isSameLocalDay(new Date(item.createdAt), new Date(now));
+  if (range === 'last7Days') return now - item.createdAt <= 7 * MS_PER_DAY;
+  if (range === 'last30Days') return now - item.createdAt <= 30 * MS_PER_DAY;
+  return now - item.createdAt > 30 * MS_PER_DAY;
+}
+
+/** 生成导出文件名 */
+export function getClipboardHistoryExportFileName(now: Date): string {
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+  const time = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `eIsland-clipboard-history-${date}-${time}.json`;
+}
+
+/** 构建导出 JSON 内容 */
+export function buildClipboardHistoryExport(items: ClipboardHistoryItem[], exportedAt: Date): string {
+  return JSON.stringify({
+    app: 'eIsland',
+    type: 'clipboard-history',
+    exportedAt: exportedAt.toISOString(),
+    count: items.length,
+    items: items.map((item) => ({
+      id: item.id,
+      text: item.text,
+      createdAt: item.createdAt,
+      createdAtText: new Date(item.createdAt).toISOString(),
+    })),
+  }, null, 2);
+}
+
+/** 下载文本文件 */
+export function downloadTextFile(fileName: string, content: string): void {
+  const blob = new Blob([content], { type: 'application/json;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/renderer/styles/settings/modules/settings-url-favorites.css
+++ b/src/renderer/styles/settings/modules/settings-url-favorites.css
@@ -880,7 +880,8 @@
   .clipboard-history-clear,
   .clipboard-history-export,
   .clipboard-history-select-toggle,
-  .clipboard-history-summary-row {
+  .clipboard-history-summary-row,
+  .clipboard-history-detail-wrapper {
     transition: none;
   }
 
@@ -969,7 +970,6 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 6px;
   border-radius: 8px;
   background: rgba(var(--color-text-rgb), 0.04);
   border: 1px solid rgba(var(--color-text-rgb), 0.06);
@@ -1078,11 +1078,26 @@
   justify-self: end;
 }
 
+.clipboard-history-detail-wrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease-out;
+}
+
+.clipboard-history-detail-wrapper--expanded {
+  grid-template-rows: 1fr;
+}
+
+.clipboard-history-detail-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
 .clipboard-history-detail {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding-top: 2px;
+  padding-top: 6px;
 }
 
 .clipboard-history-content {


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Refactor the clipboard history tab into a modular clipBoardHistory feature with dedicated hooks, utilities, and components, and update styling and imports accordingly.

Enhancements:
- Introduce a dedicated clipBoardHistory module with typed hooks, utilities, and components to manage clipboard history lifecycle, selection, filtering, and bulk operations.
- Add structured feedback handling for clipboard actions such as copy and export, including timed status messaging.
- Refine clipboard history layout and animations with a detail wrapper and grid-based expand/collapse behavior for smoother UX.
- Update max-expand viewport and lazy-loading wiring to import the clipboard history tab from the new clipBoardHistory module.