### PR TITLE
feat: 添加截图翻译历史记录和抹去记录功能

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3271,6 +3271,7 @@
         "orders": "My Orders",
         "account": "Account",
         "oauth": "Third-party App",
+        "image-translation": "Image Translation",
         "switchTo": "Switch to {{label}}"
       },
       "oauth": {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3307,6 +3307,12 @@
         "resultImageAlt": "Translated result image",
         "resultPending": "Waiting for translation result",
         "resultUnavailable": "No result image available",
+        "pagination": {
+          "label": "Image translation history pagination",
+          "previous": "Previous",
+          "next": "Next",
+          "summary": "Page {{page}} / {{totalPages}}, {{total}} total"
+        },
         "status": {
           "queued": "Queued",
           "processing": "Translating",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3295,6 +3295,27 @@
           "unbindFailed": "Failed to unbind"
         }
       },
+      "imageTranslation": {
+        "subtitle": "View original images alongside their translated results",
+        "loading": "Loading image translation history…",
+        "loadFailed": "Failed to load image translation history",
+        "empty": "No image translation history",
+        "refresh": "Refresh",
+        "refreshing": "Refreshing…",
+        "sourceImage": "Before Translation",
+        "sourceImageAlt": "Original image before translation",
+        "resultImage": "After Translation",
+        "resultImageAlt": "Translated result image",
+        "resultPending": "Waiting for translation result",
+        "resultUnavailable": "No result image available",
+        "status": {
+          "queued": "Queued",
+          "processing": "Translating",
+          "succeeded": "Completed",
+          "failed": "Failed",
+          "unknown": "Unknown"
+        }
+      },
       "recharge": {
         "title": "Recharge Balance",
         "subtitle": "Top up your balance for AI assistant conversations",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3300,8 +3300,6 @@
         "loading": "Loading image translation history…",
         "loadFailed": "Failed to load image translation history",
         "empty": "No image translation history",
-        "refresh": "Refresh",
-        "refreshing": "Refreshing…",
         "languageConnector": "to",
         "sourceImage": "Before Translation",
         "sourceImageAlt": "Original image before translation",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3307,6 +3307,7 @@
         "resultImageAlt": "Translated result image",
         "resultPending": "Waiting for translation result",
         "resultUnavailable": "No result image available",
+        "previewLabel": "Image preview",
         "pagination": {
           "label": "Image translation history pagination",
           "previous": "Previous",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3315,7 +3315,9 @@
           "downloadStarted": "Download started",
           "downloadFailed": "Download failed",
           "remove": "Remove Record",
-          "removePending": "Coming soon"
+          "removing": "Removing…",
+          "removeSuccess": "Images and translation record removed",
+          "removeFailed": "Failed to remove images"
         },
         "pagination": {
           "label": "Image translation history pagination",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3308,6 +3308,15 @@
         "resultPending": "Waiting for translation result",
         "resultUnavailable": "No result image available",
         "previewLabel": "Image preview",
+        "actions": {
+          "downloadSource": "Download Original",
+          "downloadResult": "Download Translation",
+          "downloading": "Downloading…",
+          "downloadStarted": "Download started",
+          "downloadFailed": "Download failed",
+          "remove": "Remove Record",
+          "removePending": "Coming soon"
+        },
         "pagination": {
           "label": "Image translation history pagination",
           "previous": "Previous",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3302,6 +3302,7 @@
         "empty": "No image translation history",
         "refresh": "Refresh",
         "refreshing": "Refreshing…",
+        "languageConnector": "to",
         "sourceImage": "Before Translation",
         "sourceImageAlt": "Original image before translation",
         "resultImage": "After Translation",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3300,8 +3300,6 @@
         "loading": "加载图片翻译记录中…",
         "loadFailed": "加载图片翻译记录失败",
         "empty": "暂无图片翻译记录",
-        "refresh": "刷新",
-        "refreshing": "刷新中…",
         "languageConnector": "到",
         "sourceImage": "翻译前",
         "sourceImageAlt": "翻译前图片",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3307,6 +3307,7 @@
         "resultImageAlt": "翻译后图片",
         "resultPending": "等待翻译结果",
         "resultUnavailable": "无可用结果图片",
+        "previewLabel": "图片预览",
         "pagination": {
           "label": "图片翻译历史分页",
           "previous": "上一页",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3307,6 +3307,12 @@
         "resultImageAlt": "翻译后图片",
         "resultPending": "等待翻译结果",
         "resultUnavailable": "无可用结果图片",
+        "pagination": {
+          "label": "图片翻译历史分页",
+          "previous": "上一页",
+          "next": "下一页",
+          "summary": "第 {{page}} / {{totalPages}} 页，共 {{total}} 条"
+        },
         "status": {
           "queued": "排队中",
           "processing": "翻译中",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3295,6 +3295,27 @@
           "unbindFailed": "解除绑定失败"
         }
       },
+      "imageTranslation": {
+        "subtitle": "查看原始图片与翻译后的结果图片",
+        "loading": "加载图片翻译记录中…",
+        "loadFailed": "加载图片翻译记录失败",
+        "empty": "暂无图片翻译记录",
+        "refresh": "刷新",
+        "refreshing": "刷新中…",
+        "sourceImage": "翻译前",
+        "sourceImageAlt": "翻译前图片",
+        "resultImage": "翻译后",
+        "resultImageAlt": "翻译后图片",
+        "resultPending": "等待翻译结果",
+        "resultUnavailable": "无可用结果图片",
+        "status": {
+          "queued": "排队中",
+          "processing": "翻译中",
+          "succeeded": "已完成",
+          "failed": "失败",
+          "unknown": "未知"
+        }
+      },
       "recharge": {
         "title": "余额充值",
         "subtitle": "充值后可用于 AI 助手对话消耗",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3302,6 +3302,7 @@
         "empty": "暂无图片翻译记录",
         "refresh": "刷新",
         "refreshing": "刷新中…",
+        "languageConnector": "到",
         "sourceImage": "翻译前",
         "sourceImageAlt": "翻译前图片",
         "resultImage": "翻译后",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3315,7 +3315,9 @@
           "downloadStarted": "已开始下载",
           "downloadFailed": "下载失败",
           "remove": "抹掉此记录",
-          "removePending": "暂未开放"
+          "removing": "抹掉中…",
+          "removeSuccess": "图片及翻译记录已抹掉",
+          "removeFailed": "抹掉图片失败"
         },
         "pagination": {
           "label": "图片翻译历史分页",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3271,6 +3271,7 @@
         "orders": "我的订单",
         "account": "关于账户",
         "oauth": "第三方应用绑定",
+        "image-translation": "图片翻译",
         "switchTo": "切换到{{label}}"
       },
       "oauth": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3308,6 +3308,15 @@
         "resultPending": "等待翻译结果",
         "resultUnavailable": "无可用结果图片",
         "previewLabel": "图片预览",
+        "actions": {
+          "downloadSource": "下载原始截图",
+          "downloadResult": "下载翻译截图",
+          "downloading": "下载中…",
+          "downloadStarted": "已开始下载",
+          "downloadFailed": "下载失败",
+          "remove": "抹掉此记录",
+          "removePending": "暂未开放"
+        },
         "pagination": {
           "label": "图片翻译历史分页",
           "previous": "上一页",

--- a/src/renderer/api/user/userAccountApi.client.ts
+++ b/src/renderer/api/user/userAccountApi.client.ts
@@ -118,7 +118,9 @@ function shouldAttachReplayHeaders(path: string, method: InternalRequestInit['me
   if (actualMethod !== 'POST' && actualMethod !== 'PUT' && actualMethod !== 'DELETE') return false;
   if (LOGIN_REPLAY_PATHS.has(path)) return true;
   if (!auth || auth.trim().length === 0) return false;
-  return path.startsWith('/v1/user/') || path === '/v1/upload/user-avatar';
+  return path.startsWith('/v1/user/')
+    || path === '/v1/upload/user-avatar'
+    || path.startsWith('/v1/toolbox/image-translations/');
 }
 
 /**

--- a/src/renderer/api/user/userAccountApi.translation.ts
+++ b/src/renderer/api/user/userAccountApi.translation.ts
@@ -5,10 +5,17 @@
  * Copyright (C) 2026 JNTMTMTM
  * Copyright (C) 2026 pyisland.com
  *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  */
 
 /**

--- a/src/renderer/api/user/userAccountApi.translation.ts
+++ b/src/renderer/api/user/userAccountApi.translation.ts
@@ -42,13 +42,26 @@ export interface ImageTranslationHistoryItem {
   finishedAt: string | null;
 }
 
+export interface ImageTranslationHistoryPage {
+  items: ImageTranslationHistoryItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
 export function fetchImageTranslationHistory(
   token: string,
-  limit = 100,
-): Promise<UserAccountResult<ImageTranslationHistoryItem[]>> {
-  const normalizedLimit = Math.max(1, Math.min(Number(limit) || 100, 100));
-  return request<ImageTranslationHistoryItem[]>(`/v1/toolbox/image-translations/history?limit=${normalizedLimit}`, {
-    method: 'GET',
-    auth: token,
-  });
+  page = 1,
+  pageSize = 5,
+): Promise<UserAccountResult<ImageTranslationHistoryPage>> {
+  const normalizedPage = Math.max(1, Math.floor(Number(page) || 1));
+  const normalizedPageSize = Math.max(1, Math.min(Math.floor(Number(pageSize) || 5), 100));
+  return request<ImageTranslationHistoryPage>(
+    `/v1/toolbox/image-translations/history?page=${normalizedPage}&pageSize=${normalizedPageSize}`,
+    {
+      method: 'GET',
+      auth: token,
+    },
+  );
 }

--- a/src/renderer/api/user/userAccountApi.translation.ts
+++ b/src/renderer/api/user/userAccountApi.translation.ts
@@ -1,0 +1,54 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * @file userAccountApi.translation.ts
+ * @description 当前用户图片翻译历史接口。
+ * @author 鸡哥
+ */
+
+import { request } from './userAccountApi.client';
+import type { UserAccountResult } from './userAccountApi.types';
+
+export interface ImageTranslationHistoryItem {
+  id: number;
+  taskId: string;
+  username: string;
+  mode: string;
+  status: string;
+  sourceLanguage: string;
+  targetLanguage: string;
+  sourceUrl: string;
+  resultUrl: string | null;
+  ocrResult: string | null;
+  translationResult: string | null;
+  providerTaskId: string | null;
+  providerRequestId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+}
+
+export function fetchImageTranslationHistory(
+  token: string,
+  limit = 100,
+): Promise<UserAccountResult<ImageTranslationHistoryItem[]>> {
+  const normalizedLimit = Math.max(1, Math.min(Number(limit) || 100, 100));
+  return request<ImageTranslationHistoryItem[]>(`/v1/toolbox/image-translations/history?limit=${normalizedLimit}`, {
+    method: 'GET',
+    auth: token,
+  });
+}

--- a/src/renderer/api/user/userAccountApi.translation.ts
+++ b/src/renderer/api/user/userAccountApi.translation.ts
@@ -50,6 +50,16 @@ export interface ImageTranslationHistoryPage {
   totalPages: number;
 }
 
+export function deleteImageTranslationHistory(
+  token: string,
+  taskId: string,
+): Promise<UserAccountResult<void>> {
+  return request<void>(`/v1/toolbox/image-translations/${encodeURIComponent(taskId)}`, {
+    method: 'DELETE',
+    auth: token,
+  });
+}
+
 export function fetchImageTranslationHistory(
   token: string,
   page = 1,

--- a/src/renderer/api/user/userAccountApi.translation.ts
+++ b/src/renderer/api/user/userAccountApi.translation.ts
@@ -50,6 +50,12 @@ export interface ImageTranslationHistoryPage {
   totalPages: number;
 }
 
+/**
+ * 删除指定的图片翻译记录
+ * @param token - 用户认证令牌
+ * @param taskId - 要删除的翻译任务 ID
+ * @returns 删除结果
+ */
 export function deleteImageTranslationHistory(
   token: string,
   taskId: string,
@@ -60,6 +66,13 @@ export function deleteImageTranslationHistory(
   });
 }
 
+/**
+ * 获取图片翻译历史记录（分页）
+ * @param token - 用户认证令牌
+ * @param page - 页码，默认 1
+ * @param pageSize - 每页数量，默认 5，最大 100
+ * @returns 分页的历史记录
+ */
 export function fetchImageTranslationHistory(
   token: string,
   page = 1,

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -38,7 +38,7 @@ export * from './userAccountApi.profile';
 export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
-export { fetchImageTranslationHistory } from './userAccountApi.translation';
+export { deleteImageTranslationHistory, fetchImageTranslationHistory } from './userAccountApi.translation';
 export type { ImageTranslationHistoryItem, ImageTranslationHistoryPage } from './userAccountApi.translation';
 export { fetchOAuthBindings, unbindOAuth, fetchOAuthProviders } from './userAccountApi.oauth';
 export type { OAuthBindingItem, OAuthProviderItem } from './userAccountApi.oauth';

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -38,5 +38,7 @@ export * from './userAccountApi.profile';
 export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
+export { fetchImageTranslationHistory } from './userAccountApi.translation';
+export type { ImageTranslationHistoryItem } from './userAccountApi.translation';
 export { fetchOAuthBindings, unbindOAuth, fetchOAuthProviders } from './userAccountApi.oauth';
 export type { OAuthBindingItem, OAuthProviderItem } from './userAccountApi.oauth';

--- a/src/renderer/api/user/userAccountApi.ts
+++ b/src/renderer/api/user/userAccountApi.ts
@@ -39,6 +39,6 @@ export * from './userAccountApi.feedback';
 export * from './userAccountApi.wallpaper';
 export * from './userAccountApi.payment';
 export { fetchImageTranslationHistory } from './userAccountApi.translation';
-export type { ImageTranslationHistoryItem } from './userAccountApi.translation';
+export type { ImageTranslationHistoryItem, ImageTranslationHistoryPage } from './userAccountApi.translation';
 export { fetchOAuthBindings, unbindOAuth, fetchOAuthProviders } from './userAccountApi.oauth';
 export type { OAuthBindingItem, OAuthProviderItem } from './userAccountApi.oauth';

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -1807,7 +1807,9 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               <article key={task.taskId} className="settings-user-card settings-user-image-translation-item">
                 <div className="settings-user-image-translation-item-head">
                   <div className="settings-user-image-translation-meta">
-                    <span>{task.sourceLanguage || 'auto'} → {task.targetLanguage || 'zh'}</span>
+                    <span>
+                      {task.sourceLanguage || 'auto'} {t('settings.user.imageTranslation.languageConnector', { defaultValue: '到' })} {task.targetLanguage || 'zh'}
+                    </span>
                     <span>{formatDateTime(task.createdAt)}</span>
                   </div>
                   <span className={`settings-user-image-translation-status settings-user-image-translation-status--${statusClass}`}>

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -24,7 +24,7 @@
  * @author 鸡哥
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, PointerEvent as ReactPointerEvent, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -281,6 +281,18 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
   const imageTranslationPreviewRef = useRef<HTMLButtonElement | null>(null);
   const imageTranslationPreviewDragRef = useRef<ImageTranslationPreviewDrag | null>(null);
+  const imageTranslationPreviewScaleRef = useRef(imageTranslationPreviewScale);
+
+  const getImageTranslationStatusLabel = useMemo(() => {
+    return (status: string): string => {
+      const normalized = String(status || '').toUpperCase();
+      if (normalized === 'SUCCEEDED') return t('settings.user.imageTranslation.status.succeeded', { defaultValue: '已完成' });
+      if (normalized === 'FAILED') return t('settings.user.imageTranslation.status.failed', { defaultValue: '失败' });
+      if (normalized === 'PROCESSING') return t('settings.user.imageTranslation.status.processing', { defaultValue: '翻译中' });
+      if (normalized === 'QUEUED') return t('settings.user.imageTranslation.status.queued', { defaultValue: '排队中' });
+      return status || t('settings.user.imageTranslation.status.unknown', { defaultValue: '未知' });
+    };
+  }, [t]);
 
   useEffect(() => {
     setUserProfilePage(initialProfilePage);
@@ -294,6 +306,10 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   }, [imageTranslationPreview]);
 
   useEffect(() => {
+    imageTranslationPreviewScaleRef.current = imageTranslationPreviewScale;
+  }, [imageTranslationPreviewScale]);
+
+  useEffect(() => {
     if (!imageTranslationPreview) return;
     const previewElement = imageTranslationPreviewRef.current;
     if (!previewElement) return;
@@ -303,7 +319,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       event.stopPropagation();
       const zoomFactor = Math.exp(-event.deltaY * 0.0015);
       const nextScale = clampImageTranslationPreviewScale(
-        Number((imageTranslationPreviewScale * zoomFactor).toFixed(3)),
+        Number((imageTranslationPreviewScaleRef.current * zoomFactor).toFixed(3)),
       );
       const maxX = Math.max(0, previewElement.clientWidth * (nextScale - 1) / 2);
       const maxY = Math.max(0, previewElement.clientHeight * (nextScale - 1) / 2);
@@ -316,7 +332,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
     previewElement.addEventListener('wheel', handleWheel, { passive: false });
     return () => previewElement.removeEventListener('wheel', handleWheel);
-  }, [imageTranslationPreview, imageTranslationPreviewScale]);
+  }, [imageTranslationPreview]);
 
   const handleImageTranslationPreviewPointerDown = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
     if (event.button !== 0) return;
@@ -367,6 +383,17 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     if (imageTranslationPreviewDragRef.current?.pointerId !== event.pointerId) return;
     imageTranslationPreviewDragRef.current = null;
     setImageTranslationPreviewDragging(false);
+  }, []);
+
+  const handleImageTranslationPreviewClick = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = imageTranslationPreviewDragRef.current;
+    imageTranslationPreviewDragRef.current = null;
+    if (drag?.moved) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    setImageTranslationPreview(null);
   }, []);
 
   const resetToLoggedOut = useCallback((): void => {
@@ -1971,15 +1998,6 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       </div>
     );
 
-    const getImageTranslationStatusLabel = (status: string): string => {
-      const normalized = String(status || '').toUpperCase();
-      if (normalized === 'SUCCEEDED') return t('settings.user.imageTranslation.status.succeeded', { defaultValue: '已完成' });
-      if (normalized === 'FAILED') return t('settings.user.imageTranslation.status.failed', { defaultValue: '失败' });
-      if (normalized === 'PROCESSING') return t('settings.user.imageTranslation.status.processing', { defaultValue: '翻译中' });
-      if (normalized === 'QUEUED') return t('settings.user.imageTranslation.status.queued', { defaultValue: '排队中' });
-      return status || t('settings.user.imageTranslation.status.unknown', { defaultValue: '未知' });
-    };
-
     const renderImageTranslationPage = (): ReactElement => (
       <div className="settings-user-page-panel settings-user-image-translation-panel">
         <div className="settings-user-card settings-user-image-translation-head-card">
@@ -2034,16 +2052,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                     onPointerMove={handleImageTranslationPreviewPointerMove}
                     onPointerUp={handleImageTranslationPreviewPointerUp}
                     onPointerCancel={handleImageTranslationPreviewPointerCancel}
-                    onClick={(event) => {
-                      const drag = imageTranslationPreviewDragRef.current;
-                      imageTranslationPreviewDragRef.current = null;
-                      if (drag?.moved) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        return;
-                      }
-                      setImageTranslationPreview(null);
-                    }}
+                    onClick={handleImageTranslationPreviewClick}
                   >
                     <img
                       src={imageTranslationPreview.url}
@@ -2056,134 +2065,134 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   </button>
                 ) : (
                   <>
-                <div className="settings-user-image-translation-item-head">
-                  <div className="settings-user-image-translation-meta">
-                    <span className="settings-user-image-translation-language-route">
-                      <span className="settings-user-image-translation-language">
-                        {sourceLanguageIcon.src ? (
-                          <img
-                            className={sourceLanguageIcon.isAuto ? 'is-auto' : ''}
-                            src={sourceLanguageIcon.src}
-                            alt=""
-                            aria-hidden="true"
-                            draggable={false}
-                          />
-                        ) : null}
-                        <span>{sourceLanguage}</span>
+                    <div className="settings-user-image-translation-item-head">
+                      <div className="settings-user-image-translation-meta">
+                        <span className="settings-user-image-translation-language-route">
+                          <span className="settings-user-image-translation-language">
+                            {sourceLanguageIcon.src ? (
+                              <img
+                                className={sourceLanguageIcon.isAuto ? 'is-auto' : ''}
+                                src={sourceLanguageIcon.src}
+                                alt=""
+                                aria-hidden="true"
+                                draggable={false}
+                              />
+                            ) : null}
+                            <span>{sourceLanguage}</span>
+                          </span>
+                          <span>{t('settings.user.imageTranslation.languageConnector', { defaultValue: '到' })}</span>
+                          <span className="settings-user-image-translation-language">
+                            {targetLanguageIcon.src ? (
+                              <img
+                                className={targetLanguageIcon.isAuto ? 'is-auto' : ''}
+                                src={targetLanguageIcon.src}
+                                alt=""
+                                aria-hidden="true"
+                                draggable={false}
+                              />
+                            ) : null}
+                            <span>{targetLanguage}</span>
+                          </span>
+                        </span>
+                        <span>{formatDateTime(task.createdAt)}</span>
+                      </div>
+                      <span className={`settings-user-image-translation-status settings-user-image-translation-status--${statusClass}`}>
+                        {getImageTranslationStatusLabel(task.status)}
                       </span>
-                      <span>{t('settings.user.imageTranslation.languageConnector', { defaultValue: '到' })}</span>
-                      <span className="settings-user-image-translation-language">
-                        {targetLanguageIcon.src ? (
-                          <img
-                            className={targetLanguageIcon.isAuto ? 'is-auto' : ''}
-                            src={targetLanguageIcon.src}
-                            alt=""
-                            aria-hidden="true"
-                            draggable={false}
-                          />
-                        ) : null}
-                        <span>{targetLanguage}</span>
-                      </span>
-                    </span>
-                    <span>{formatDateTime(task.createdAt)}</span>
-                  </div>
-                  <span className={`settings-user-image-translation-status settings-user-image-translation-status--${statusClass}`}>
-                    {getImageTranslationStatusLabel(task.status)}
-                  </span>
-                </div>
+                    </div>
 
-                <div className="settings-user-image-translation-images">
-                  <figure className="settings-user-image-translation-image-card">
-                    <figcaption>{t('settings.user.imageTranslation.sourceImage', { defaultValue: '翻译前' })}</figcaption>
-                    <button
-                      type="button"
-                      className="settings-user-image-translation-image-wrap"
-                      onClick={() => setImageTranslationPreview({
-                        taskId: task.taskId,
-                        url: task.sourceUrl,
-                        alt: t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' }),
-                      })}
-                    >
-                      <img
-                        src={task.sourceUrl}
-                        alt={t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' })}
-                        loading="lazy"
-                        draggable={false}
-                      />
-                    </button>
-                  </figure>
-
-                  <figure className="settings-user-image-translation-image-card">
-                    <figcaption>{t('settings.user.imageTranslation.resultImage', { defaultValue: '翻译后' })}</figcaption>
-                      {resultUrl ? (
+                    <div className="settings-user-image-translation-images">
+                      <figure className="settings-user-image-translation-image-card">
+                        <figcaption>{t('settings.user.imageTranslation.sourceImage', { defaultValue: '翻译前' })}</figcaption>
                         <button
                           type="button"
                           className="settings-user-image-translation-image-wrap"
                           onClick={() => setImageTranslationPreview({
                             taskId: task.taskId,
-                            url: resultUrl,
-                            alt: t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' }),
+                            url: task.sourceUrl,
+                            alt: t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' }),
                           })}
                         >
                           <img
-                            src={resultUrl}
-                            alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
+                            src={task.sourceUrl}
+                            alt={t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' })}
                             loading="lazy"
                             draggable={false}
                           />
                         </button>
-                      ) : (
-                        <div className="settings-user-image-translation-image-wrap">
-                          <span className="settings-user-image-translation-image-placeholder">
-                            {normalizedStatus === 'FAILED'
-                              ? t('settings.user.imageTranslation.resultUnavailable', { defaultValue: '无可用结果图片' })
-                              : t('settings.user.imageTranslation.resultPending', { defaultValue: '等待翻译结果' })}
-                          </span>
-                        </div>
-                      )}
-                  </figure>
-                </div>
+                      </figure>
 
-                <div className="settings-user-image-translation-actions">
-                  <button
-                    type="button"
-                    className="settings-hotkey-btn"
-                    disabled={Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
-                    onClick={() => void handleDownloadImageTranslationImage(task, 'source', task.sourceUrl)}
-                  >
-                    {imageTranslationDownloadingKey === `${task.taskId}:source`
-                      ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
-                      : t('settings.user.imageTranslation.actions.downloadSource', { defaultValue: '下载原始截图' })}
-                  </button>
-                  <button
-                    type="button"
-                    className="settings-hotkey-btn"
-                    disabled={!resultUrl || Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
-                    onClick={() => void handleDownloadImageTranslationImage(task, 'result', resultUrl)}
-                  >
-                    {imageTranslationDownloadingKey === `${task.taskId}:result`
-                      ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
-                      : t('settings.user.imageTranslation.actions.downloadResult', { defaultValue: '下载翻译截图' })}
-                  </button>
-                  <button
-                    type="button"
-                    className="settings-hotkey-btn settings-user-image-translation-remove"
-                    disabled={!canRemove || Boolean(imageTranslationRemovingTaskId) || Boolean(imageTranslationDownloadingKey)}
-                    onClick={() => void handleRemoveImageTranslation(task)}
-                  >
-                    {imageTranslationRemovingTaskId === task.taskId
-                      ? t('settings.user.imageTranslation.actions.removing', { defaultValue: '抹掉中…' })
-                      : t('settings.user.imageTranslation.actions.remove', { defaultValue: '抹掉此记录' })}
-                  </button>
-                </div>
+                      <figure className="settings-user-image-translation-image-card">
+                        <figcaption>{t('settings.user.imageTranslation.resultImage', { defaultValue: '翻译后' })}</figcaption>
+                        {resultUrl ? (
+                          <button
+                            type="button"
+                            className="settings-user-image-translation-image-wrap"
+                            onClick={() => setImageTranslationPreview({
+                              taskId: task.taskId,
+                              url: resultUrl,
+                              alt: t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' }),
+                            })}
+                          >
+                            <img
+                              src={resultUrl}
+                              alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
+                              loading="lazy"
+                              draggable={false}
+                            />
+                          </button>
+                        ) : (
+                          <div className="settings-user-image-translation-image-wrap">
+                            <span className="settings-user-image-translation-image-placeholder">
+                              {normalizedStatus === 'FAILED'
+                                ? t('settings.user.imageTranslation.resultUnavailable', { defaultValue: '无可用结果图片' })
+                                : t('settings.user.imageTranslation.resultPending', { defaultValue: '等待翻译结果' })}
+                            </span>
+                          </div>
+                        )}
+                      </figure>
+                    </div>
 
-                {imageTranslationActionFeedback?.taskId === task.taskId
-                  ? renderFeedback(imageTranslationActionFeedback.feedback)
-                  : null}
+                    <div className="settings-user-image-translation-actions">
+                      <button
+                        type="button"
+                        className="settings-hotkey-btn"
+                        disabled={Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
+                        onClick={() => void handleDownloadImageTranslationImage(task, 'source', task.sourceUrl)}
+                      >
+                        {imageTranslationDownloadingKey === `${task.taskId}:source`
+                          ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
+                          : t('settings.user.imageTranslation.actions.downloadSource', { defaultValue: '下载原始截图' })}
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-hotkey-btn"
+                        disabled={!resultUrl || Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
+                        onClick={() => void handleDownloadImageTranslationImage(task, 'result', resultUrl)}
+                      >
+                        {imageTranslationDownloadingKey === `${task.taskId}:result`
+                          ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
+                          : t('settings.user.imageTranslation.actions.downloadResult', { defaultValue: '下载翻译截图' })}
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-hotkey-btn settings-user-image-translation-remove"
+                        disabled={!canRemove || Boolean(imageTranslationRemovingTaskId) || Boolean(imageTranslationDownloadingKey)}
+                        onClick={() => void handleRemoveImageTranslation(task)}
+                      >
+                        {imageTranslationRemovingTaskId === task.taskId
+                          ? t('settings.user.imageTranslation.actions.removing', { defaultValue: '抹掉中…' })
+                          : t('settings.user.imageTranslation.actions.remove', { defaultValue: '抹掉此记录' })}
+                      </button>
+                    </div>
 
-                {task.errorMessage ? (
-                  <div className="settings-user-image-translation-error">{task.errorMessage}</div>
-                ) : null}
+                    {imageTranslationActionFeedback?.taskId === task.taskId
+                      ? renderFeedback(imageTranslationActionFeedback.feedback)
+                      : null}
+
+                    {task.errorMessage ? (
+                      <div className="settings-user-image-translation-error">{task.errorMessage}</div>
+                    ) : null}
                   </>
                 )}
               </article>

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -89,6 +89,12 @@ interface UserSettingsSectionProps {
 
 const GENDER_VALUES: UserAccountGender[] = ['male', 'female', 'custom', 'undisclosed'];
 const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account', 'oauth', 'image-translation'];
+const IMAGE_TRANSLATION_PREVIEW_MIN_SCALE = 0.5;
+const IMAGE_TRANSLATION_PREVIEW_MAX_SCALE = 4;
+
+const clampImageTranslationPreviewScale = (value: number): number => {
+  return Math.min(IMAGE_TRANSLATION_PREVIEW_MAX_SCALE, Math.max(IMAGE_TRANSLATION_PREVIEW_MIN_SCALE, value));
+};
 const IMAGE_TRANSLATION_HISTORY_PAGE_SIZE = 5;
 
 const getGenderIcon = (gender: UserAccountGender | null | undefined): string => {
@@ -219,6 +225,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [loadingImageTranslationHistory, setLoadingImageTranslationHistory] = useState(false);
   const [imageTranslationHistoryError, setImageTranslationHistoryError] = useState('');
   const [imageTranslationPreview, setImageTranslationPreview] = useState<ImageTranslationPreview | null>(null);
+  const [imageTranslationPreviewScale, setImageTranslationPreviewScale] = useState(1);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -246,10 +253,30 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   });
 
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
+  const imageTranslationPreviewRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     setUserProfilePage(initialProfilePage);
   }, [initialProfilePage]);
+
+  useEffect(() => {
+    setImageTranslationPreviewScale(1);
+    if (!imageTranslationPreview) return;
+    const previewElement = imageTranslationPreviewRef.current;
+    if (!previewElement) return;
+
+    const handleWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      const zoomFactor = Math.exp(-event.deltaY * 0.0015);
+      setImageTranslationPreviewScale((current) => {
+        return clampImageTranslationPreviewScale(Number((current * zoomFactor).toFixed(3)));
+      });
+    };
+
+    previewElement.addEventListener('wheel', handleWheel, { passive: false });
+    return () => previewElement.removeEventListener('wheel', handleWheel);
+  }, [imageTranslationPreview]);
 
   const resetToLoggedOut = useCallback((): void => {
     clearLocalAccount();
@@ -1828,6 +1855,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               <article key={task.taskId} className="settings-user-card settings-user-image-translation-item">
                 {imageTranslationPreview?.taskId === task.taskId ? (
                   <button
+                    ref={imageTranslationPreviewRef}
                     type="button"
                     className="settings-user-image-translation-preview"
                     aria-label={t('settings.user.imageTranslation.previewLabel', { defaultValue: '图片预览' })}
@@ -1837,6 +1865,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                       src={imageTranslationPreview.url}
                       alt={imageTranslationPreview.alt}
                       draggable={false}
+                      style={{ transform: `scale(${imageTranslationPreviewScale})` }}
                     />
                   </button>
                 ) : (

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -65,7 +65,7 @@ import { SettingsPageNavigation, SettingsPageNavigationToggle } from '../Setting
 import '../../../../../../../styles/settings/modules/cli.css';
 
 type FeedbackType = 'success' | 'error' | 'info';
-type UserProfilePage = 'info' | 'edit' | 'password' | 'pro' | 'recharge' | 'orders' | 'account' | 'oauth';
+type UserProfilePage = 'info' | 'edit' | 'password' | 'pro' | 'recharge' | 'orders' | 'account' | 'oauth' | 'image-translation';
 
 interface Feedback {
   type: FeedbackType;
@@ -79,7 +79,7 @@ interface UserSettingsSectionProps {
 }
 
 const GENDER_VALUES: UserAccountGender[] = ['male', 'female', 'custom', 'undisclosed'];
-const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account', 'oauth'];
+const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account', 'oauth', 'image-translation'];
 
 const getGenderIcon = (gender: UserAccountGender | null | undefined): string => {
   if (gender === 'male') return SvgIcon.BOY;
@@ -214,7 +214,9 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                 ? '我的订单'
                 : userProfilePage === 'account'
                   ? '关于账户'
-                  : '第三方应用绑定',
+                  : userProfilePage === 'oauth'
+                    ? '第三方应用绑定'
+                    : '图片翻译',
   });
 
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
@@ -1047,6 +1049,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       { id: 'orders', label: t('settings.user.pages.orders', { defaultValue: '我的订单' }) },
       { id: 'account', label: t('settings.user.pages.account', { defaultValue: '关于账户' }) },
       { id: 'oauth', label: t('settings.user.pages.oauth', { defaultValue: '第三方应用绑定' }) },
+      { id: 'image-translation', label: t('settings.user.pages.image-translation', { defaultValue: '图片翻译' }) },
     ];
     const profilePageLabels = Object.fromEntries(
       profilePageItems.map((item) => [item.id, item.label]),
@@ -1800,6 +1803,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
           {userProfilePage === 'orders' && renderOrdersPage()}
           {userProfilePage === 'account' && renderAccountPage()}
           {userProfilePage === 'oauth' && renderOAuthPage()}
+          {userProfilePage === 'image-translation' && <div className="settings-user-page-panel" />}
         </div>
 
         <SettingsPageNavigation

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -83,6 +83,7 @@ interface UserSettingsSectionProps {
 
 const GENDER_VALUES: UserAccountGender[] = ['male', 'female', 'custom', 'undisclosed'];
 const USER_PROFILE_PAGES: UserProfilePage[] = ['info', 'edit', 'password', 'pro', 'recharge', 'orders', 'account', 'oauth', 'image-translation'];
+const IMAGE_TRANSLATION_HISTORY_PAGE_SIZE = 5;
 
 const getGenderIcon = (gender: UserAccountGender | null | undefined): string => {
   if (gender === 'male') return SvgIcon.BOY;
@@ -206,6 +207,9 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [oauthFeedback, setOauthFeedback] = useState<{ bindingId: number; feedback: Feedback } | null>(null);
 
   const [imageTranslationHistory, setImageTranslationHistory] = useState<ImageTranslationHistoryItem[]>([]);
+  const [imageTranslationHistoryPage, setImageTranslationHistoryPage] = useState(1);
+  const [imageTranslationHistoryTotal, setImageTranslationHistoryTotal] = useState(0);
+  const [imageTranslationHistoryTotalPages, setImageTranslationHistoryTotalPages] = useState(0);
   const [loadingImageTranslationHistory, setLoadingImageTranslationHistory] = useState(false);
   const [imageTranslationHistoryError, setImageTranslationHistoryError] = useState('');
 
@@ -521,18 +525,21 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
   }, [loadRemoteProfile, resetToLoggedOut, t, token]);
 
-  const loadImageTranslationHistory = useCallback(async (): Promise<void> => {
+  const loadImageTranslationHistory = useCallback(async (page: number): Promise<void> => {
     if (!token) {
       setImageTranslationHistory([]);
+      setImageTranslationHistoryPage(1);
+      setImageTranslationHistoryTotal(0);
+      setImageTranslationHistoryTotalPages(0);
       setLoadingImageTranslationHistory(false);
       setImageTranslationHistoryError('');
       return;
     }
     setLoadingImageTranslationHistory(true);
     setImageTranslationHistoryError('');
-    const result = await fetchImageTranslationHistory(token, 100);
+    const result = await fetchImageTranslationHistory(token, page, IMAGE_TRANSLATION_HISTORY_PAGE_SIZE);
     setLoadingImageTranslationHistory(false);
-    if (!result.ok || !Array.isArray(result.data)) {
+    if (!result.ok || !result.data || !Array.isArray(result.data.items)) {
       if (result.code === 401 || result.code === 4011) {
         resetToLoggedOut();
         return;
@@ -540,7 +547,10 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       setImageTranslationHistoryError(result.message || t('settings.user.imageTranslation.loadFailed', { defaultValue: '加载图片翻译记录失败' }));
       return;
     }
-    setImageTranslationHistory(result.data);
+    setImageTranslationHistory(result.data.items);
+    setImageTranslationHistoryPage(result.data.page);
+    setImageTranslationHistoryTotal(result.data.total);
+    setImageTranslationHistoryTotalPages(result.data.totalPages);
   }, [resetToLoggedOut, t, token]);
 
   useEffect(() => {
@@ -554,8 +564,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     if (userProfilePage !== 'image-translation' || !token) {
       return;
     }
-    void loadImageTranslationHistory();
-  }, [loadImageTranslationHistory, token, userProfilePage]);
+    void loadImageTranslationHistory(imageTranslationHistoryPage);
+  }, [imageTranslationHistoryPage, loadImageTranslationHistory, token, userProfilePage]);
 
   useEffect(() => {
     if (userProfilePage !== 'oauth' || !token) {
@@ -1885,6 +1895,35 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
             );
           })}
         </div>
+
+        {imageTranslationHistoryTotalPages > 0 ? (
+          <nav className="settings-plugin-market-pagination settings-user-image-translation-pagination" aria-label={t('settings.user.imageTranslation.pagination.label', { defaultValue: '图片翻译历史分页' })}>
+            <button
+              type="button"
+              className="settings-hotkey-btn"
+              disabled={loadingImageTranslationHistory || imageTranslationHistoryPage <= 1}
+              onClick={() => setImageTranslationHistoryPage((current) => Math.max(1, current - 1))}
+            >
+              {t('settings.user.imageTranslation.pagination.previous', { defaultValue: '上一页' })}
+            </button>
+            <span className="settings-plugin-market-pagination-text settings-user-image-translation-pagination-summary">
+              {t('settings.user.imageTranslation.pagination.summary', {
+                defaultValue: '第 {{page}} / {{totalPages}} 页，共 {{total}} 条',
+                page: imageTranslationHistoryPage,
+                totalPages: imageTranslationHistoryTotalPages,
+                total: imageTranslationHistoryTotal,
+              })}
+            </span>
+            <button
+              type="button"
+              className="settings-hotkey-btn"
+              disabled={loadingImageTranslationHistory || imageTranslationHistoryPage >= imageTranslationHistoryTotalPages}
+              onClick={() => setImageTranslationHistoryPage((current) => Math.min(imageTranslationHistoryTotalPages, current + 1))}
+            >
+              {t('settings.user.imageTranslation.pagination.next', { defaultValue: '下一页' })}
+            </button>
+          </nav>
+        ) : null}
       </div>
     );
 

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -104,6 +104,17 @@ const IMAGE_TRANSLATION_PREVIEW_MAX_SCALE = 4;
 const clampImageTranslationPreviewScale = (value: number): number => {
   return Math.min(IMAGE_TRANSLATION_PREVIEW_MAX_SCALE, Math.max(IMAGE_TRANSLATION_PREVIEW_MIN_SCALE, value));
 };
+
+const buildImageTranslationDownloadName = (taskId: string, kind: 'source' | 'result', imageUrl: string): string => {
+  let extension = '.jpg';
+  try {
+    const matchedExtension = new URL(imageUrl).pathname.match(/\.(jpe?g|png|webp)$/i)?.[0];
+    if (matchedExtension) extension = matchedExtension.toLowerCase();
+  } catch {
+    // 使用默认扩展名。
+  }
+  return `image-translation-${taskId.slice(0, 8)}-${kind}${extension}`;
+};
 const IMAGE_TRANSLATION_HISTORY_PAGE_SIZE = 5;
 
 const getGenderIcon = (gender: UserAccountGender | null | undefined): string => {
@@ -237,6 +248,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [imageTranslationPreviewScale, setImageTranslationPreviewScale] = useState(1);
   const [imageTranslationPreviewOffset, setImageTranslationPreviewOffset] = useState({ x: 0, y: 0 });
   const [imageTranslationPreviewDragging, setImageTranslationPreviewDragging] = useState(false);
+  const [imageTranslationDownloadingKey, setImageTranslationDownloadingKey] = useState('');
+  const [imageTranslationActionFeedback, setImageTranslationActionFeedback] = useState<{ taskId: string; feedback: Feedback } | null>(null);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -663,6 +676,37 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     setImageTranslationHistoryTotal(result.data.total);
     setImageTranslationHistoryTotalPages(result.data.totalPages);
   }, [resetToLoggedOut, t, token]);
+
+  const handleDownloadImageTranslationImage = useCallback(async (
+    task: ImageTranslationHistoryItem,
+    kind: 'source' | 'result',
+    imageUrl: string | null,
+  ): Promise<void> => {
+    if (!imageUrl || imageTranslationDownloadingKey) return;
+    const actionKey = `${task.taskId}:${kind}`;
+    setImageTranslationDownloadingKey(actionKey);
+    setImageTranslationActionFeedback(null);
+    try {
+      const savePath = await window.api.downloadPickSavePath(
+        buildImageTranslationDownloadName(task.taskId, kind, imageUrl),
+      );
+      if (!savePath) return;
+      const result = await window.api.downloadStart({ url: imageUrl, savePath, threads: 4 });
+      setImageTranslationActionFeedback({
+        taskId: task.taskId,
+        feedback: result.ok
+          ? { type: 'success', text: t('settings.user.imageTranslation.actions.downloadStarted', { defaultValue: '已开始下载' }) }
+          : { type: 'error', text: result.message || t('settings.user.imageTranslation.actions.downloadFailed', { defaultValue: '下载失败' }) },
+      });
+    } catch {
+      setImageTranslationActionFeedback({
+        taskId: task.taskId,
+        feedback: { type: 'error', text: t('settings.user.imageTranslation.actions.downloadFailed', { defaultValue: '下载失败' }) },
+      });
+    } finally {
+      setImageTranslationDownloadingKey('');
+    }
+  }, [imageTranslationDownloadingKey, t]);
 
   useEffect(() => {
     if (userProfilePage !== 'orders' || !token) {
@@ -2048,6 +2092,41 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                       )}
                   </figure>
                 </div>
+
+                <div className="settings-user-image-translation-actions">
+                  <button
+                    type="button"
+                    className="settings-hotkey-btn"
+                    disabled={Boolean(imageTranslationDownloadingKey)}
+                    onClick={() => void handleDownloadImageTranslationImage(task, 'source', task.sourceUrl)}
+                  >
+                    {imageTranslationDownloadingKey === `${task.taskId}:source`
+                      ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
+                      : t('settings.user.imageTranslation.actions.downloadSource', { defaultValue: '下载原始截图' })}
+                  </button>
+                  <button
+                    type="button"
+                    className="settings-hotkey-btn"
+                    disabled={!task.resultUrl || Boolean(imageTranslationDownloadingKey)}
+                    onClick={() => void handleDownloadImageTranslationImage(task, 'result', task.resultUrl)}
+                  >
+                    {imageTranslationDownloadingKey === `${task.taskId}:result`
+                      ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })
+                      : t('settings.user.imageTranslation.actions.downloadResult', { defaultValue: '下载翻译截图' })}
+                  </button>
+                  <button
+                    type="button"
+                    className="settings-hotkey-btn settings-user-image-translation-remove"
+                    disabled
+                    title={t('settings.user.imageTranslation.actions.removePending', { defaultValue: '暂未开放' })}
+                  >
+                    {t('settings.user.imageTranslation.actions.remove', { defaultValue: '抹掉此记录' })}
+                  </button>
+                </div>
+
+                {imageTranslationActionFeedback?.taskId === task.taskId
+                  ? renderFeedback(imageTranslationActionFeedback.feedback)
+                  : null}
 
                 {task.errorMessage ? (
                   <div className="settings-user-image-translation-error">{task.errorMessage}</div>

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -1969,6 +1969,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
             const statusClass = normalizedStatus.toLowerCase().replace(/[^a-z0-9-]/g, '') || 'unknown';
             const sourceLanguage = task.sourceLanguage || 'auto';
             const targetLanguage = task.targetLanguage || 'zh';
+            const resultUrl = typeof task.resultUrl === 'string' ? task.resultUrl.trim() : '';
             const sourceLanguageIcon = resolveImageTranslationLanguageIcon(sourceLanguage);
             const targetLanguageIcon = resolveImageTranslationLanguageIcon(targetLanguage);
             return (
@@ -2064,18 +2065,18 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
                   <figure className="settings-user-image-translation-image-card">
                     <figcaption>{t('settings.user.imageTranslation.resultImage', { defaultValue: '翻译后' })}</figcaption>
-                      {task.resultUrl ? (
+                      {resultUrl ? (
                         <button
                           type="button"
                           className="settings-user-image-translation-image-wrap"
                           onClick={() => setImageTranslationPreview({
                             taskId: task.taskId,
-                            url: task.resultUrl as string,
+                            url: resultUrl,
                             alt: t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' }),
                           })}
                         >
                           <img
-                            src={task.resultUrl}
+                            src={resultUrl}
                             alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
                             loading="lazy"
                             draggable={false}
@@ -2107,8 +2108,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   <button
                     type="button"
                     className="settings-hotkey-btn"
-                    disabled={!task.resultUrl || Boolean(imageTranslationDownloadingKey)}
-                    onClick={() => void handleDownloadImageTranslationImage(task, 'result', task.resultUrl)}
+                    disabled={!resultUrl || Boolean(imageTranslationDownloadingKey)}
+                    onClick={() => void handleDownloadImageTranslationImage(task, 'result', resultUrl)}
                   >
                     {imageTranslationDownloadingKey === `${task.taskId}:result`
                       ? t('settings.user.imageTranslation.actions.downloading', { defaultValue: '下载中…' })

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -29,6 +29,7 @@ import type { ChangeEvent, PointerEvent as ReactPointerEvent, ReactElement } fro
 import { useTranslation } from 'react-i18next';
 import {
   closeUserPaymentOrder,
+  deleteImageTranslationHistory,
   fetchUserPaymentOrders,
   fetchProMonthPricing,
   fetchAgentBalance,
@@ -249,6 +250,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [imageTranslationPreviewOffset, setImageTranslationPreviewOffset] = useState({ x: 0, y: 0 });
   const [imageTranslationPreviewDragging, setImageTranslationPreviewDragging] = useState(false);
   const [imageTranslationDownloadingKey, setImageTranslationDownloadingKey] = useState('');
+  const [imageTranslationRemovingTaskId, setImageTranslationRemovingTaskId] = useState('');
   const [imageTranslationActionFeedback, setImageTranslationActionFeedback] = useState<{ taskId: string; feedback: Feedback } | null>(null);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
@@ -707,6 +709,53 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       setImageTranslationDownloadingKey('');
     }
   }, [imageTranslationDownloadingKey, t]);
+
+  const handleRemoveImageTranslation = useCallback(async (
+    task: ImageTranslationHistoryItem,
+  ): Promise<void> => {
+    if (!token || imageTranslationRemovingTaskId || imageTranslationDownloadingKey) return;
+    setImageTranslationRemovingTaskId(task.taskId);
+    setImageTranslationActionFeedback(null);
+    const result = await deleteImageTranslationHistory(token, task.taskId);
+    setImageTranslationRemovingTaskId('');
+    if (!result.ok) {
+      if (result.code === 401 || result.code === 4011) {
+        resetToLoggedOut();
+        return;
+      }
+      setImageTranslationActionFeedback({
+        taskId: task.taskId,
+        feedback: {
+          type: 'error',
+          text: result.message || t('settings.user.imageTranslation.actions.removeFailed', { defaultValue: '抹掉图片失败' }),
+        },
+      });
+      return;
+    }
+
+    setImageTranslationPreview((current) => current?.taskId === task.taskId ? null : current);
+    setImageTranslationActionFeedback({
+      taskId: task.taskId,
+      feedback: {
+        type: 'success',
+        text: t('settings.user.imageTranslation.actions.removeSuccess', { defaultValue: '图片及翻译记录已抹掉' }),
+      },
+    });
+    if (imageTranslationHistory.length === 1 && imageTranslationHistoryPage > 1) {
+      setImageTranslationHistoryPage((current) => Math.max(1, current - 1));
+      return;
+    }
+    await loadImageTranslationHistory(imageTranslationHistoryPage);
+  }, [
+    imageTranslationDownloadingKey,
+    imageTranslationHistory.length,
+    imageTranslationHistoryPage,
+    imageTranslationRemovingTaskId,
+    loadImageTranslationHistory,
+    resetToLoggedOut,
+    t,
+    token,
+  ]);
 
   useEffect(() => {
     if (userProfilePage !== 'orders' || !token) {
@@ -1966,6 +2015,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
         <div className="settings-user-image-translation-list">
           {imageTranslationHistory.map((task) => {
             const normalizedStatus = String(task.status || '').toUpperCase();
+            const canRemove = normalizedStatus === 'SUCCEEDED' || normalizedStatus === 'FAILED';
             const statusClass = normalizedStatus.toLowerCase().replace(/[^a-z0-9-]/g, '') || 'unknown';
             const sourceLanguage = task.sourceLanguage || 'auto';
             const targetLanguage = task.targetLanguage || 'zh';
@@ -2098,7 +2148,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   <button
                     type="button"
                     className="settings-hotkey-btn"
-                    disabled={Boolean(imageTranslationDownloadingKey)}
+                    disabled={Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
                     onClick={() => void handleDownloadImageTranslationImage(task, 'source', task.sourceUrl)}
                   >
                     {imageTranslationDownloadingKey === `${task.taskId}:source`
@@ -2108,7 +2158,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   <button
                     type="button"
                     className="settings-hotkey-btn"
-                    disabled={!resultUrl || Boolean(imageTranslationDownloadingKey)}
+                    disabled={!resultUrl || Boolean(imageTranslationDownloadingKey) || Boolean(imageTranslationRemovingTaskId)}
                     onClick={() => void handleDownloadImageTranslationImage(task, 'result', resultUrl)}
                   >
                     {imageTranslationDownloadingKey === `${task.taskId}:result`
@@ -2118,10 +2168,12 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   <button
                     type="button"
                     className="settings-hotkey-btn settings-user-image-translation-remove"
-                    disabled
-                    title={t('settings.user.imageTranslation.actions.removePending', { defaultValue: '暂未开放' })}
+                    disabled={!canRemove || Boolean(imageTranslationRemovingTaskId) || Boolean(imageTranslationDownloadingKey)}
+                    onClick={() => void handleRemoveImageTranslation(task)}
                   >
-                    {t('settings.user.imageTranslation.actions.remove', { defaultValue: '抹掉此记录' })}
+                    {imageTranslationRemovingTaskId === task.taskId
+                      ? t('settings.user.imageTranslation.actions.removing', { defaultValue: '抹掉中…' })
+                      : t('settings.user.imageTranslation.actions.remove', { defaultValue: '抹掉此记录' })}
                   </button>
                 </div>
 

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -75,6 +75,12 @@ interface Feedback {
   text: string;
 }
 
+interface ImageTranslationPreview {
+  taskId: string;
+  url: string;
+  alt: string;
+}
+
 type ProfileFeedbackScope = 'profile' | 'password' | 'account';
 
 interface UserSettingsSectionProps {
@@ -212,6 +218,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [imageTranslationHistoryTotalPages, setImageTranslationHistoryTotalPages] = useState(0);
   const [loadingImageTranslationHistory, setLoadingImageTranslationHistory] = useState(false);
   const [imageTranslationHistoryError, setImageTranslationHistoryError] = useState('');
+  const [imageTranslationPreview, setImageTranslationPreview] = useState<ImageTranslationPreview | null>(null);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -537,6 +544,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
     setLoadingImageTranslationHistory(true);
     setImageTranslationHistoryError('');
+    setImageTranslationPreview(null);
     const result = await fetchImageTranslationHistory(token, page, IMAGE_TRANSLATION_HISTORY_PAGE_SIZE);
     setLoadingImageTranslationHistory(false);
     if (!result.ok || !result.data || !Array.isArray(result.data.items)) {
@@ -1818,6 +1826,21 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
             const targetLanguageIcon = resolveImageTranslationLanguageIcon(targetLanguage);
             return (
               <article key={task.taskId} className="settings-user-card settings-user-image-translation-item">
+                {imageTranslationPreview?.taskId === task.taskId ? (
+                  <button
+                    type="button"
+                    className="settings-user-image-translation-preview"
+                    aria-label={t('settings.user.imageTranslation.previewLabel', { defaultValue: '图片预览' })}
+                    onClick={() => setImageTranslationPreview(null)}
+                  >
+                    <img
+                      src={imageTranslationPreview.url}
+                      alt={imageTranslationPreview.alt}
+                      draggable={false}
+                    />
+                  </button>
+                ) : (
+                  <>
                 <div className="settings-user-image-translation-item-head">
                   <div className="settings-user-image-translation-meta">
                     <span className="settings-user-image-translation-language-route">
@@ -1857,40 +1880,60 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                 <div className="settings-user-image-translation-images">
                   <figure className="settings-user-image-translation-image-card">
                     <figcaption>{t('settings.user.imageTranslation.sourceImage', { defaultValue: '翻译前' })}</figcaption>
-                    <div className="settings-user-image-translation-image-wrap">
+                    <button
+                      type="button"
+                      className="settings-user-image-translation-image-wrap"
+                      onClick={() => setImageTranslationPreview({
+                        taskId: task.taskId,
+                        url: task.sourceUrl,
+                        alt: t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' }),
+                      })}
+                    >
                       <img
                         src={task.sourceUrl}
                         alt={t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' })}
                         loading="lazy"
                         draggable={false}
                       />
-                    </div>
+                    </button>
                   </figure>
 
                   <figure className="settings-user-image-translation-image-card">
                     <figcaption>{t('settings.user.imageTranslation.resultImage', { defaultValue: '翻译后' })}</figcaption>
-                    <div className="settings-user-image-translation-image-wrap">
                       {task.resultUrl ? (
-                        <img
-                          src={task.resultUrl}
-                          alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
-                          loading="lazy"
-                          draggable={false}
-                        />
+                        <button
+                          type="button"
+                          className="settings-user-image-translation-image-wrap"
+                          onClick={() => setImageTranslationPreview({
+                            taskId: task.taskId,
+                            url: task.resultUrl as string,
+                            alt: t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' }),
+                          })}
+                        >
+                          <img
+                            src={task.resultUrl}
+                            alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
+                            loading="lazy"
+                            draggable={false}
+                          />
+                        </button>
                       ) : (
-                        <span className="settings-user-image-translation-image-placeholder">
-                          {normalizedStatus === 'FAILED'
-                            ? t('settings.user.imageTranslation.resultUnavailable', { defaultValue: '无可用结果图片' })
-                            : t('settings.user.imageTranslation.resultPending', { defaultValue: '等待翻译结果' })}
-                        </span>
+                        <div className="settings-user-image-translation-image-wrap">
+                          <span className="settings-user-image-translation-image-placeholder">
+                            {normalizedStatus === 'FAILED'
+                              ? t('settings.user.imageTranslation.resultUnavailable', { defaultValue: '无可用结果图片' })
+                              : t('settings.user.imageTranslation.resultPending', { defaultValue: '等待翻译结果' })}
+                          </span>
+                        </div>
                       )}
-                    </div>
                   </figure>
                 </div>
 
                 {task.errorMessage ? (
                   <div className="settings-user-image-translation-error">{task.errorMessage}</div>
                 ) : null}
+                  </>
+                )}
               </article>
             );
           })}

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -32,6 +32,7 @@ import {
   fetchUserPaymentOrders,
   fetchProMonthPricing,
   fetchAgentBalance,
+  fetchImageTranslationHistory,
   fetchOAuthBindings,
   fetchUserProfile,
   logoutUser,
@@ -42,6 +43,7 @@ import {
   updateUserPassword,
   updateUserProfile,
   uploadUserAvatar,
+  type ImageTranslationHistoryItem,
   type OAuthBindingItem,
   type UserPaymentOrderData,
 } from '../../../../../../../api/user/userAccountApi';
@@ -193,6 +195,10 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [loadingOAuthBindings, setLoadingOAuthBindings] = useState(false);
   const [oauthUnbindingId, setOauthUnbindingId] = useState<number | null>(null);
   const [oauthFeedback, setOauthFeedback] = useState<{ bindingId: number; feedback: Feedback } | null>(null);
+
+  const [imageTranslationHistory, setImageTranslationHistory] = useState<ImageTranslationHistoryItem[]>([]);
+  const [loadingImageTranslationHistory, setLoadingImageTranslationHistory] = useState(false);
+  const [imageTranslationHistoryError, setImageTranslationHistoryError] = useState('');
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -506,12 +512,41 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
   }, [loadRemoteProfile, resetToLoggedOut, t, token]);
 
+  const loadImageTranslationHistory = useCallback(async (): Promise<void> => {
+    if (!token) {
+      setImageTranslationHistory([]);
+      setLoadingImageTranslationHistory(false);
+      setImageTranslationHistoryError('');
+      return;
+    }
+    setLoadingImageTranslationHistory(true);
+    setImageTranslationHistoryError('');
+    const result = await fetchImageTranslationHistory(token, 100);
+    setLoadingImageTranslationHistory(false);
+    if (!result.ok || !Array.isArray(result.data)) {
+      if (result.code === 401 || result.code === 4011) {
+        resetToLoggedOut();
+        return;
+      }
+      setImageTranslationHistoryError(result.message || t('settings.user.imageTranslation.loadFailed', { defaultValue: '加载图片翻译记录失败' }));
+      return;
+    }
+    setImageTranslationHistory(result.data);
+  }, [resetToLoggedOut, t, token]);
+
   useEffect(() => {
     if (userProfilePage !== 'orders' || !token) {
       return;
     }
     void loadUserOrders();
   }, [loadUserOrders, token, userProfilePage]);
+
+  useEffect(() => {
+    if (userProfilePage !== 'image-translation' || !token) {
+      return;
+    }
+    void loadImageTranslationHistory();
+  }, [loadImageTranslationHistory, token, userProfilePage]);
 
   useEffect(() => {
     if (userProfilePage !== 'oauth' || !token) {
@@ -1713,6 +1748,117 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       </div>
     );
 
+    const getImageTranslationStatusLabel = (status: string): string => {
+      const normalized = String(status || '').toUpperCase();
+      if (normalized === 'SUCCEEDED') return t('settings.user.imageTranslation.status.succeeded', { defaultValue: '已完成' });
+      if (normalized === 'FAILED') return t('settings.user.imageTranslation.status.failed', { defaultValue: '失败' });
+      if (normalized === 'PROCESSING') return t('settings.user.imageTranslation.status.processing', { defaultValue: '翻译中' });
+      if (normalized === 'QUEUED') return t('settings.user.imageTranslation.status.queued', { defaultValue: '排队中' });
+      return status || t('settings.user.imageTranslation.status.unknown', { defaultValue: '未知' });
+    };
+
+    const renderImageTranslationPage = (): ReactElement => (
+      <div className="settings-user-page-panel settings-user-image-translation-panel">
+        <div className="settings-user-card settings-user-image-translation-head-card">
+          <div className="settings-user-image-translation-head">
+            <div>
+              <div className="settings-user-form-title">{t('settings.user.pages.image-translation', { defaultValue: '图片翻译' })}</div>
+              <div className="settings-user-card-title-hint">
+                {t('settings.user.imageTranslation.subtitle', { defaultValue: '查看原始图片与翻译后的结果图片' })}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="settings-user-secondary-btn settings-user-image-translation-refresh"
+              onClick={() => void loadImageTranslationHistory()}
+              disabled={loadingImageTranslationHistory}
+            >
+              {loadingImageTranslationHistory
+                ? t('settings.user.imageTranslation.refreshing', { defaultValue: '刷新中…' })
+                : t('settings.user.imageTranslation.refresh', { defaultValue: '刷新' })}
+            </button>
+          </div>
+        </div>
+
+        {loadingImageTranslationHistory && imageTranslationHistory.length === 0 ? (
+          <div className="settings-user-card settings-user-image-translation-state">
+            <span className="settings-user-orders-inline-spinner" aria-hidden="true" />
+            <span>{t('settings.user.imageTranslation.loading', { defaultValue: '加载图片翻译记录中…' })}</span>
+          </div>
+        ) : null}
+
+        {imageTranslationHistoryError ? (
+          <div className="settings-user-feedback settings-user-feedback--error">
+            {imageTranslationHistoryError}
+          </div>
+        ) : null}
+
+        {!loadingImageTranslationHistory && !imageTranslationHistoryError && imageTranslationHistory.length === 0 ? (
+          <div className="settings-user-card settings-user-image-translation-state">
+            {t('settings.user.imageTranslation.empty', { defaultValue: '暂无图片翻译记录' })}
+          </div>
+        ) : null}
+
+        <div className="settings-user-image-translation-list">
+          {imageTranslationHistory.map((task) => {
+            const normalizedStatus = String(task.status || '').toUpperCase();
+            const statusClass = normalizedStatus.toLowerCase().replace(/[^a-z0-9-]/g, '') || 'unknown';
+            return (
+              <article key={task.taskId} className="settings-user-card settings-user-image-translation-item">
+                <div className="settings-user-image-translation-item-head">
+                  <div className="settings-user-image-translation-meta">
+                    <span>{task.sourceLanguage || 'auto'} → {task.targetLanguage || 'zh'}</span>
+                    <span>{formatDateTime(task.createdAt)}</span>
+                  </div>
+                  <span className={`settings-user-image-translation-status settings-user-image-translation-status--${statusClass}`}>
+                    {getImageTranslationStatusLabel(task.status)}
+                  </span>
+                </div>
+
+                <div className="settings-user-image-translation-images">
+                  <figure className="settings-user-image-translation-image-card">
+                    <figcaption>{t('settings.user.imageTranslation.sourceImage', { defaultValue: '翻译前' })}</figcaption>
+                    <div className="settings-user-image-translation-image-wrap">
+                      <img
+                        src={task.sourceUrl}
+                        alt={t('settings.user.imageTranslation.sourceImageAlt', { defaultValue: '翻译前图片' })}
+                        loading="lazy"
+                        draggable={false}
+                      />
+                    </div>
+                  </figure>
+
+                  <figure className="settings-user-image-translation-image-card">
+                    <figcaption>{t('settings.user.imageTranslation.resultImage', { defaultValue: '翻译后' })}</figcaption>
+                    <div className="settings-user-image-translation-image-wrap">
+                      {task.resultUrl ? (
+                        <img
+                          src={task.resultUrl}
+                          alt={t('settings.user.imageTranslation.resultImageAlt', { defaultValue: '翻译后图片' })}
+                          loading="lazy"
+                          draggable={false}
+                        />
+                      ) : (
+                        <span className="settings-user-image-translation-image-placeholder">
+                          {normalizedStatus === 'FAILED'
+                            ? t('settings.user.imageTranslation.resultUnavailable', { defaultValue: '无可用结果图片' })
+                            : t('settings.user.imageTranslation.resultPending', { defaultValue: '等待翻译结果' })}
+                        </span>
+                      )}
+                    </div>
+                  </figure>
+                </div>
+
+                {task.errorMessage ? (
+                  <div className="settings-user-image-translation-error">{task.errorMessage}</div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    );
+
     const rechargeAmountYuan = rechargeSelected !== null && rechargeSelected !== undefined
       ? rechargeSelected
       : (rechargeCustomValue.trim() !== '' ? parseFloat(rechargeCustomValue) : NaN);
@@ -1803,7 +1949,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
           {userProfilePage === 'orders' && renderOrdersPage()}
           {userProfilePage === 'account' && renderAccountPage()}
           {userProfilePage === 'oauth' && renderOAuthPage()}
-          {userProfilePage === 'image-translation' && <div className="settings-user-page-panel" />}
+          {userProfilePage === 'image-translation' && renderImageTranslationPage()}
         </div>
 
         <SettingsPageNavigation

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -1767,16 +1767,6 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                 {t('settings.user.imageTranslation.subtitle', { defaultValue: '查看原始图片与翻译后的结果图片' })}
               </div>
             </div>
-            <button
-              type="button"
-              className="settings-user-secondary-btn settings-user-image-translation-refresh"
-              onClick={() => void loadImageTranslationHistory()}
-              disabled={loadingImageTranslationHistory}
-            >
-              {loadingImageTranslationHistory
-                ? t('settings.user.imageTranslation.refreshing', { defaultValue: '刷新中…' })
-                : t('settings.user.imageTranslation.refresh', { defaultValue: '刷新' })}
-            </button>
           </div>
         </div>
 

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -25,7 +25,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ChangeEvent, ReactElement } from 'react';
+import type { ChangeEvent, PointerEvent as ReactPointerEvent, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   closeUserPaymentOrder,
@@ -79,6 +79,15 @@ interface ImageTranslationPreview {
   taskId: string;
   url: string;
   alt: string;
+}
+
+interface ImageTranslationPreviewDrag {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+  moved: boolean;
 }
 
 type ProfileFeedbackScope = 'profile' | 'password' | 'account';
@@ -226,6 +235,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [imageTranslationHistoryError, setImageTranslationHistoryError] = useState('');
   const [imageTranslationPreview, setImageTranslationPreview] = useState<ImageTranslationPreview | null>(null);
   const [imageTranslationPreviewScale, setImageTranslationPreviewScale] = useState(1);
+  const [imageTranslationPreviewOffset, setImageTranslationPreviewOffset] = useState({ x: 0, y: 0 });
+  const [imageTranslationPreviewDragging, setImageTranslationPreviewDragging] = useState(false);
 
   /** 用户中心登录天数热力图：记录并展示当前用户每个自然日是否登录 */
   const [loginDays, setLoginDays] = useState<Set<string>>(() => readLoginDays(profile?.username));
@@ -254,6 +265,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
   const imageTranslationPreviewRef = useRef<HTMLButtonElement | null>(null);
+  const imageTranslationPreviewDragRef = useRef<ImageTranslationPreviewDrag | null>(null);
 
   useEffect(() => {
     setUserProfilePage(initialProfilePage);
@@ -261,6 +273,12 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
 
   useEffect(() => {
     setImageTranslationPreviewScale(1);
+    setImageTranslationPreviewOffset({ x: 0, y: 0 });
+    setImageTranslationPreviewDragging(false);
+    imageTranslationPreviewDragRef.current = null;
+  }, [imageTranslationPreview]);
+
+  useEffect(() => {
     if (!imageTranslationPreview) return;
     const previewElement = imageTranslationPreviewRef.current;
     if (!previewElement) return;
@@ -269,14 +287,72 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       event.preventDefault();
       event.stopPropagation();
       const zoomFactor = Math.exp(-event.deltaY * 0.0015);
-      setImageTranslationPreviewScale((current) => {
-        return clampImageTranslationPreviewScale(Number((current * zoomFactor).toFixed(3)));
-      });
+      const nextScale = clampImageTranslationPreviewScale(
+        Number((imageTranslationPreviewScale * zoomFactor).toFixed(3)),
+      );
+      const maxX = Math.max(0, previewElement.clientWidth * (nextScale - 1) / 2);
+      const maxY = Math.max(0, previewElement.clientHeight * (nextScale - 1) / 2);
+      setImageTranslationPreviewScale(nextScale);
+      setImageTranslationPreviewOffset((current) => ({
+        x: Math.min(maxX, Math.max(-maxX, current.x)),
+        y: Math.min(maxY, Math.max(-maxY, current.y)),
+      }));
     };
 
     previewElement.addEventListener('wheel', handleWheel, { passive: false });
     return () => previewElement.removeEventListener('wheel', handleWheel);
-  }, [imageTranslationPreview]);
+  }, [imageTranslationPreview, imageTranslationPreviewScale]);
+
+  const handleImageTranslationPreviewPointerDown = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    imageTranslationPreviewDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: imageTranslationPreviewOffset.x,
+      originY: imageTranslationPreviewOffset.y,
+      moved: false,
+    };
+    setImageTranslationPreviewDragging(true);
+  }, [imageTranslationPreviewOffset]);
+
+  const handleImageTranslationPreviewPointerMove = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = imageTranslationPreviewDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const deltaX = event.clientX - drag.startX;
+    const deltaY = event.clientY - drag.startY;
+    if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) {
+      drag.moved = true;
+    }
+    const maxX = Math.max(0, event.currentTarget.clientWidth * (imageTranslationPreviewScale - 1) / 2);
+    const maxY = Math.max(0, event.currentTarget.clientHeight * (imageTranslationPreviewScale - 1) / 2);
+    setImageTranslationPreviewOffset({
+      x: Math.min(maxX, Math.max(-maxX, drag.originX + deltaX)),
+      y: Math.min(maxY, Math.max(-maxY, drag.originY + deltaY)),
+    });
+  }, [imageTranslationPreviewScale]);
+
+  const handleImageTranslationPreviewPointerUp = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = imageTranslationPreviewDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setImageTranslationPreviewDragging(false);
+  }, []);
+
+  const handleImageTranslationPreviewPointerCancel = useCallback((event: ReactPointerEvent<HTMLButtonElement>): void => {
+    if (imageTranslationPreviewDragRef.current?.pointerId !== event.pointerId) return;
+    imageTranslationPreviewDragRef.current = null;
+    setImageTranslationPreviewDragging(false);
+  }, []);
 
   const resetToLoggedOut = useCallback((): void => {
     clearLocalAccount();
@@ -1857,15 +1933,30 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
                   <button
                     ref={imageTranslationPreviewRef}
                     type="button"
-                    className="settings-user-image-translation-preview"
+                    className={`settings-user-image-translation-preview${imageTranslationPreviewDragging ? ' is-dragging' : ''}`}
                     aria-label={t('settings.user.imageTranslation.previewLabel', { defaultValue: '图片预览' })}
-                    onClick={() => setImageTranslationPreview(null)}
+                    onPointerDown={handleImageTranslationPreviewPointerDown}
+                    onPointerMove={handleImageTranslationPreviewPointerMove}
+                    onPointerUp={handleImageTranslationPreviewPointerUp}
+                    onPointerCancel={handleImageTranslationPreviewPointerCancel}
+                    onClick={(event) => {
+                      const drag = imageTranslationPreviewDragRef.current;
+                      imageTranslationPreviewDragRef.current = null;
+                      if (drag?.moved) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        return;
+                      }
+                      setImageTranslationPreview(null);
+                    }}
                   >
                     <img
                       src={imageTranslationPreview.url}
                       alt={imageTranslationPreview.alt}
                       draggable={false}
-                      style={{ transform: `scale(${imageTranslationPreviewScale})` }}
+                      style={{
+                        transform: `translate3d(${imageTranslationPreviewOffset.x}px, ${imageTranslationPreviewOffset.y}px, 0) scale(${imageTranslationPreviewScale})`,
+                      }}
                     />
                   </button>
                 ) : (

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -60,6 +60,7 @@ import {
   type UserAccountProfile,
 } from '../../../../../../../utils/userAccount';
 import { SvgIcon } from '../../../../../../../utils/SvgIcon';
+import { resolveCountryIcon } from '../../../../../../../utils/SvgIcon/country-icon';
 import { EMAIL_PATTERN } from '../../../../../../../components/config/dynamicIslandPatterns';
 import { LoginHeatmap } from './components/LoginHeatmap';
 import { readLoginDays, recordLoginDay } from './utils/loginHeatmapStorage';
@@ -97,6 +98,14 @@ const shouldKeepGenderIconOriginalColor = (gender: UserAccountGender | null | un
 const formatDateTime = (value: string | null | undefined): string => {
   if (!value) return '—';
   return value.replace('T', ' ');
+};
+
+const resolveImageTranslationLanguageIcon = (language: string): { src?: string; isAuto: boolean } => {
+  const normalized = String(language || '').trim().toLowerCase();
+  if (normalized === 'auto') {
+    return { src: SvgIcon.AI, isAuto: true };
+  }
+  return { src: resolveCountryIcon(normalized), isAuto: false };
 };
 
 const normalizeRoleValue = (value: string): string => {
@@ -1793,12 +1802,40 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
           {imageTranslationHistory.map((task) => {
             const normalizedStatus = String(task.status || '').toUpperCase();
             const statusClass = normalizedStatus.toLowerCase().replace(/[^a-z0-9-]/g, '') || 'unknown';
+            const sourceLanguage = task.sourceLanguage || 'auto';
+            const targetLanguage = task.targetLanguage || 'zh';
+            const sourceLanguageIcon = resolveImageTranslationLanguageIcon(sourceLanguage);
+            const targetLanguageIcon = resolveImageTranslationLanguageIcon(targetLanguage);
             return (
               <article key={task.taskId} className="settings-user-card settings-user-image-translation-item">
                 <div className="settings-user-image-translation-item-head">
                   <div className="settings-user-image-translation-meta">
-                    <span>
-                      {task.sourceLanguage || 'auto'} {t('settings.user.imageTranslation.languageConnector', { defaultValue: '到' })} {task.targetLanguage || 'zh'}
+                    <span className="settings-user-image-translation-language-route">
+                      <span className="settings-user-image-translation-language">
+                        {sourceLanguageIcon.src ? (
+                          <img
+                            className={sourceLanguageIcon.isAuto ? 'is-auto' : ''}
+                            src={sourceLanguageIcon.src}
+                            alt=""
+                            aria-hidden="true"
+                            draggable={false}
+                          />
+                        ) : null}
+                        <span>{sourceLanguage}</span>
+                      </span>
+                      <span>{t('settings.user.imageTranslation.languageConnector', { defaultValue: '到' })}</span>
+                      <span className="settings-user-image-translation-language">
+                        {targetLanguageIcon.src ? (
+                          <img
+                            className={targetLanguageIcon.isAuto ? 'is-auto' : ''}
+                            src={targetLanguageIcon.src}
+                            alt=""
+                            aria-hidden="true"
+                            draggable={false}
+                          />
+                        ) : null}
+                        <span>{targetLanguage}</span>
+                      </span>
                     </span>
                     <span>{formatDateTime(task.createdAt)}</span>
                   </div>

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5536,6 +5536,18 @@
   cursor: not-allowed;
 }
 
+.settings-user-image-translation-actions .settings-user-image-translation-remove {
+  color: rgba(248, 113, 113, 0.92);
+  border-color: rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.settings-user-image-translation-actions .settings-user-image-translation-remove:not(:disabled):hover {
+  color: rgba(254, 202, 202, 1);
+  border-color: rgba(248, 113, 113, 0.44);
+  background: rgba(248, 113, 113, 0.18);
+}
+
 .settings-user-image-translation-actions .settings-user-image-translation-remove:disabled,
 .settings-user-image-translation-actions .settings-user-image-translation-remove:disabled:hover {
   color: rgba(248, 113, 113, 0.6);

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5525,10 +5525,23 @@
   white-space: nowrap;
 }
 
-.settings-user-image-translation-remove:disabled {
+.settings-user-image-translation-actions .settings-hotkey-btn:disabled,
+.settings-user-image-translation-actions .settings-hotkey-btn:disabled:hover {
+  color: rgba(var(--color-text-rgb), 0.28);
+  border-color: rgba(var(--color-text-rgb), 0.055);
+  background: rgba(var(--color-text-rgb), 0.025);
+  box-shadow: none;
+  filter: grayscale(0.45);
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
+.settings-user-image-translation-actions .settings-user-image-translation-remove:disabled,
+.settings-user-image-translation-actions .settings-user-image-translation-remove:disabled:hover {
   color: rgba(248, 113, 113, 0.6);
   border-color: rgba(248, 113, 113, 0.16);
   background: rgba(248, 113, 113, 0.06);
+  filter: grayscale(0.15);
 }
 
 .settings-user-image-translation-actions + .settings-user-feedback {

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5384,6 +5384,154 @@
   justify-content: center;
 }
 
+/* ── Image Translation History Page ── */
+
+.settings-user-image-translation-panel {
+  gap: 10px;
+}
+
+.settings-user-image-translation-head-card {
+  gap: 8px;
+}
+
+.settings-user-image-translation-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-user-image-translation-refresh {
+  flex-shrink: 0;
+}
+
+.settings-user-image-translation-state {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(var(--color-text-rgb), 0.56);
+}
+
+.settings-user-image-translation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-user-image-translation-item {
+  gap: 10px;
+}
+
+.settings-user-image-translation-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-user-image-translation-meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 10px;
+  color: rgba(var(--color-text-rgb), 0.54);
+}
+
+.settings-user-image-translation-meta span:first-child {
+  color: rgba(var(--color-text-rgb), 0.86);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.settings-user-image-translation-status {
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--color-text-rgb), 0.18);
+  background: rgba(var(--color-text-rgb), 0.08);
+  color: rgba(var(--color-text-rgb), 0.72);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.settings-user-image-translation-status--succeeded {
+  color: rgba(74, 222, 128, 1);
+  border-color: rgba(74, 222, 128, 0.28);
+  background: rgba(74, 222, 128, 0.12);
+}
+
+.settings-user-image-translation-status--failed {
+  color: rgba(248, 113, 113, 1);
+  border-color: rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.settings-user-image-translation-status--processing,
+.settings-user-image-translation-status--queued {
+  color: rgba(96, 165, 250, 1);
+  border-color: rgba(96, 165, 250, 0.28);
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.settings-user-image-translation-images {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-user-image-translation-image-card {
+  min-width: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-user-image-translation-image-card figcaption {
+  font-size: 10px;
+  color: rgba(var(--color-text-rgb), 0.58);
+}
+
+.settings-user-image-translation-image-wrap {
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 9px;
+  border: 1px solid rgba(var(--color-text-rgb), 0.09);
+  background: rgba(var(--color-text-rgb), 0.035);
+}
+
+.settings-user-image-translation-image-wrap img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+}
+
+.settings-user-image-translation-image-placeholder {
+  padding: 12px;
+  text-align: center;
+  font-size: 11px;
+  color: rgba(var(--color-text-rgb), 0.42);
+}
+
+.settings-user-image-translation-error {
+  padding: 7px 9px;
+  border-radius: 7px;
+  background: rgba(248, 113, 113, 0.08);
+  color: rgba(248, 113, 113, 0.88);
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 760px) {
   .settings-user-avatar-row {
     grid-template-columns: 1fr;
@@ -5406,6 +5554,20 @@
 
   .settings-user-pro-grid {
     grid-template-columns: 1fr;
+  }
+
+  .settings-user-image-translation-head,
+  .settings-user-image-translation-item-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-user-image-translation-images {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-user-image-translation-image-wrap {
+    height: 220px;
   }
 }
 

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5582,6 +5582,8 @@ button.settings-user-image-translation-image-wrap:hover {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  overscroll-behavior: contain;
+  touch-action: none;
   border: 0;
   background: transparent;
   cursor: zoom-out;
@@ -5592,6 +5594,10 @@ button.settings-user-image-translation-image-wrap:hover {
   height: 100%;
   display: block;
   object-fit: contain;
+  transform-origin: center;
+  will-change: transform;
+  pointer-events: none;
+  user-select: none;
 }
 
 @media (max-width: 760px) {

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5418,6 +5418,9 @@
 }
 
 .settings-user-image-translation-item {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   padding: 8px 14px 12px;
   gap: 7px;
 }
@@ -5523,7 +5526,9 @@
 }
 
 .settings-user-image-translation-image-wrap {
+  width: 100%;
   height: 180px;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5531,6 +5536,18 @@
   border-radius: 9px;
   border: 1px solid rgba(var(--color-text-rgb), 0.09);
   background: rgba(var(--color-text-rgb), 0.035);
+  color: inherit;
+  font: inherit;
+}
+
+button.settings-user-image-translation-image-wrap {
+  cursor: zoom-in;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+button.settings-user-image-translation-image-wrap:hover {
+  border-color: rgba(var(--color-text-rgb), 0.2);
+  background: rgba(var(--color-text-rgb), 0.065);
 }
 
 .settings-user-image-translation-image-wrap img {
@@ -5555,6 +5572,26 @@
   font-size: 10px;
   line-height: 1.45;
   overflow-wrap: anywhere;
+}
+
+.settings-user-image-translation-preview {
+  width: 100%;
+  height: 220px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  cursor: zoom-out;
+}
+
+.settings-user-image-translation-preview > img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
 }
 
 @media (max-width: 760px) {

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5586,7 +5586,11 @@ button.settings-user-image-translation-image-wrap:hover {
   touch-action: none;
   border: 0;
   background: transparent;
-  cursor: zoom-out;
+  cursor: grab;
+}
+
+.settings-user-image-translation-preview.is-dragging {
+  cursor: grabbing;
 }
 
 .settings-user-image-translation-preview > img {

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5445,6 +5445,34 @@
   text-transform: uppercase;
 }
 
+.settings-user-image-translation-language-route,
+.settings-user-image-translation-language {
+  display: inline-flex;
+  align-items: center;
+}
+
+.settings-user-image-translation-language-route {
+  gap: 6px;
+}
+
+.settings-user-image-translation-language {
+  gap: 4px;
+}
+
+.settings-user-image-translation-language img {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.settings-user-image-translation-language img.is-auto {
+  width: 14px;
+  height: 14px;
+  opacity: 0.85;
+  filter: invert(calc(1 - var(--icon-invert)));
+}
+
 .settings-user-image-translation-status {
   flex-shrink: 0;
   padding: 3px 8px;

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5512,6 +5512,29 @@
   gap: 10px;
 }
 
+.settings-user-image-translation-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.settings-user-image-translation-actions .settings-hotkey-btn {
+  width: 100%;
+  min-width: 0;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.settings-user-image-translation-remove:disabled {
+  color: rgba(248, 113, 113, 0.6);
+  border-color: rgba(248, 113, 113, 0.16);
+  background: rgba(248, 113, 113, 0.06);
+}
+
+.settings-user-image-translation-actions + .settings-user-feedback {
+  margin-top: 0;
+}
+
 .settings-user-image-translation-image-card {
   min-width: 0;
   margin: 0;

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5422,7 +5422,8 @@
 }
 
 .settings-user-image-translation-item {
-  gap: 10px;
+  padding: 8px 14px 12px;
+  gap: 7px;
 }
 
 .settings-user-image-translation-item-head {

--- a/src/renderer/styles/settings/modules/settings-layout.css
+++ b/src/renderer/styles/settings/modules/settings-layout.css
@@ -5401,10 +5401,6 @@
   gap: 12px;
 }
 
-.settings-user-image-translation-refresh {
-  flex-shrink: 0;
-}
-
 .settings-user-image-translation-state {
   min-height: 72px;
   display: flex;


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Add a new image translation history management page to user settings with preview, download, and deletion capabilities for translated screenshots, backed by new API endpoints and styling.

New Features:
- Introduce an 'image-translation' tab in user settings to browse screenshot translation history with pagination.
- Enable zoomable and draggable image preview for original and translated screenshots within the history view.
- Allow downloading original and translated images and erasing individual translation records from the user interface.

Enhancements:
- Extend authenticated request handling to cover image translation toolbox endpoints.
- Add language flag resolution and new styles for the image translation history layout and status badges.