### PR TITLE
feat: 添加截图翻译源语言和目标语言配置界面和对应功能

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1951,6 +1951,7 @@
       "notification": "Notification Settings",
       "performance": "Performance Settings",
       "performance-monitor": "Performance Monitor",
+      "screenshot-settings": "Screenshot Settings",
       "network": "Network",
       "mail": "Mail",
       "weather": "Weather",
@@ -2111,6 +2112,10 @@
           "memory": "Memory",
           "disk": "Disk"
         }
+      },
+      "screenshotSettings": {
+        "title": "Screenshot Settings",
+        "hint": "Configure screenshot related settings."
       },
       "notifications": {
         "configChanged": {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -2115,7 +2115,9 @@
       },
       "screenshotSettings": {
         "title": "Screenshot Settings",
-        "hint": "Configure screenshot related settings."
+        "hint": "Configure screenshot related settings.",
+        "translateTitle": "Screenshot Translation Language",
+        "translateHint": "Configure source and target languages for screenshot translation."
       },
       "notifications": {
         "configChanged": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -1951,6 +1951,7 @@
       "notification": "通知设置",
       "performance": "性能设置",
       "performance-monitor": "性能监控",
+      "screenshot-settings": "截图设置",
       "network": "网络配置",
       "mail": "邮箱配置",
       "weather": "天气配置",
@@ -2111,6 +2112,10 @@
           "memory": "内存",
           "disk": "磁盘"
         }
+      },
+      "screenshotSettings": {
+        "title": "截图设置",
+        "hint": "截图相关配置。"
       },
       "notifications": {
         "configChanged": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -2115,7 +2115,9 @@
       },
       "screenshotSettings": {
         "title": "截图设置",
-        "hint": "截图相关配置。"
+        "hint": "截图相关配置。",
+        "translateTitle": "截图翻译语言",
+        "translateHint": "配置截图翻译的源语言和目标语言。"
       },
       "notifications": {
         "configChanged": {

--- a/resources/capture.js
+++ b/resources/capture.js
@@ -949,10 +949,17 @@ btnTranslate.addEventListener('click', async () => {
     if (typeof token !== 'string' || !token.trim()) {
       throw new Error(tCapture('loginRequired'));
     }
+    const [storedSourceLang, storedTargetLang] = await Promise.all([
+      ipcRenderer.invoke('store:read', 'screenshot-translate-source-lang'),
+      ipcRenderer.invoke('store:read', 'screenshot-translate-target-lang'),
+    ]);
+    const sourceLanguage = typeof storedSourceLang === 'string' && storedSourceLang ? storedSourceLang : 'auto';
+    const targetLanguage = typeof storedTargetLang === 'string' && storedTargetLang ? storedTargetLang : 'en';
     const result = await ipcRenderer.invoke('capture-translate', {
       dataURL: originalImage,
       token,
-      targetLanguage: captureLanguage === 'en-US' ? 'en' : 'zh',
+      sourceLanguage,
+      targetLanguage,
     });
     if (!result?.success || !result.translatedImage) {
       const errorCode = result?.code;

--- a/src/main/ipc/window/capture.ts
+++ b/src/main/ipc/window/capture.ts
@@ -87,6 +87,7 @@ export function registerCaptureIpcHandlers(options: RegisterCaptureIpcHandlersOp
   ipcMain.handle('capture-translate', async (event, payload: {
     dataURL: string;
     token: string;
+    sourceLanguage: string;
     targetLanguage: string;
   }) => {
     const captureWindow = options.getCaptureWindow();
@@ -101,7 +102,8 @@ export function registerCaptureIpcHandlers(options: RegisterCaptureIpcHandlersOp
       return await translateCaptureImage(
         typeof payload?.token === 'string' ? payload.token : '',
         typeof payload?.dataURL === 'string' ? payload.dataURL : '',
-        payload?.targetLanguage === 'en' ? 'en' : 'zh',
+        typeof payload?.sourceLanguage === 'string' && payload.sourceLanguage ? payload.sourceLanguage : 'auto',
+        typeof payload?.targetLanguage === 'string' && payload.targetLanguage ? payload.targetLanguage : 'zh',
         controller.signal,
       );
     } finally {

--- a/src/main/services/imageTranslationService.ts
+++ b/src/main/services/imageTranslationService.ts
@@ -133,6 +133,7 @@ async function downloadAsDataUrl(url: string, signal: AbortSignal): Promise<stri
 export async function translateCaptureImage(
   token: string,
   dataUrl: string,
+  sourceLanguage: string,
   targetLanguage: string,
   signal: AbortSignal,
 ): Promise<CaptureTranslationResult> {
@@ -142,8 +143,8 @@ export async function translateCaptureImage(
   try {
     const formData = new FormData();
     formData.append('file', dataUrlToBlob(dataUrl), 'capture-translate.png');
-    formData.append('sourceLanguage', 'auto');
-    formData.append('targetLanguage', targetLanguage === 'en' ? 'en' : 'zh');
+    formData.append('sourceLanguage', sourceLanguage || 'auto');
+    formData.append('targetLanguage', targetLanguage || 'zh');
 
     const submitted = await parseApiResponse(await requestWithTimeout(
       `${API_BASE}/v1/toolbox/image-translations`,

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/AppSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/AppSettingsSection.tsx
@@ -45,6 +45,7 @@ import { SoundSettingsPage } from './components/SoundSettingsPage';
 import { NotificationSettingsPage } from './components/NotificationSettingsPage';
 import { PerformanceSettingsPage } from './components/PerformanceSettingsPage';
 import { PerformanceMonitorSettingsPage } from './components/PerformanceMonitorSettingsPage';
+import { ScreenshotSettingsPage } from './components/ScreenshotSettingsPage';
 import { AppSettingsPageDots } from './components/AppSettingsPageDots';
 import { SettingsPageNavigationToggle } from '../SettingsPageNavigation';
 import type { AppSettingsSectionProps } from './components/types';
@@ -336,6 +337,8 @@ export function AppSettingsSection({
         return <PerformanceSettingsPage />;
       case 'performance-monitor':
         return <PerformanceMonitorSettingsPage />;
+      case 'screenshot-settings':
+        return <ScreenshotSettingsPage />;
       default:
         return null;
     }

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ScreenshotSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ScreenshotSettingsPage.tsx
@@ -1,0 +1,41 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file ScreenshotSettingsPage.tsx
+ * @description 设置页面 - 软件设置截图设置子界面
+ * @author 鸡哥
+ */
+
+import type { ReactElement } from 'react';
+
+/**
+ * 渲染截图设置页面
+ * @returns 截图设置页面
+ */
+export function ScreenshotSettingsPage(): ReactElement {
+  return (
+    <div className="settings-screenshot-page-panel">
+      <div className="settings-cards">
+        {/* TODO: 截图设置内容待实现 */}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ScreenshotSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ScreenshotSettingsPage.tsx
@@ -24,17 +24,188 @@
  * @author 鸡哥
  */
 
-import type { ReactElement } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { SvgIcon } from '../../../../../../../../utils/SvgIcon';
+import { resolveCountryIcon } from '../../../../../../../../utils/SvgIcon/country-icon';
+import { TRANSLATE_LANGUAGES, TRANSLATE_TARGET_LANGUAGES } from '../../../../tools/config/translateToolConfig';
+import {
+  SCREENSHOT_TRANSLATE_SOURCE_LANG_STORE_KEY,
+  SCREENSHOT_TRANSLATE_TARGET_LANG_STORE_KEY,
+} from '../../../config/settingsTabConfig';
+
+/** 翻译语言选项 */
+interface LangOption {
+  readonly code: string;
+  readonly labelKey: string;
+}
+
+/**
+ * 翻译语言下拉选择器
+ * @param options - 可选语言列表
+ * @param value - 当前选中的语言代码
+ * @param onChange - 语言变更回调
+ */
+function TranslateLangDropdown({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly LangOption[];
+  value: string;
+  onChange: (code: string) => void;
+}): ReactElement {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent): void => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const selected = options.find((o) => o.code === value);
+  const selectedFlag = resolveCountryIcon(value);
+  const selectedIcon = selectedFlag ?? (value === 'auto' ? SvgIcon.AI : undefined);
+
+  return (
+    <div className="translate-lang-dropdown" ref={wrapperRef}>
+      <button
+        type="button"
+        className="translate-lang-dropdown-trigger"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {selectedIcon ? (
+          <img
+            className={selectedFlag ? 'translate-lang-flag no-filter' : 'translate-lang-ai-icon'}
+            src={selectedIcon}
+            alt=""
+            draggable={false}
+          />
+        ) : (
+          <span className="translate-lang-flag-placeholder" />
+        )}
+        <span className="translate-lang-dropdown-label">
+          {selected ? t(selected.labelKey) : value}
+        </span>
+        <span className="translate-lang-dropdown-arrow">▾</span>
+      </button>
+      {open && (
+        <div className="translate-lang-dropdown-menu">
+          {options.map((lang) => {
+            const flag = resolveCountryIcon(lang.code);
+            const icon = flag ?? (lang.code === 'auto' ? SvgIcon.AI : undefined);
+            return (
+              <button
+                key={lang.code}
+                type="button"
+                className={`translate-lang-dropdown-item ${lang.code === value ? 'active' : ''}`}
+                onClick={() => {
+                  onChange(lang.code);
+                  setOpen(false);
+                }}
+              >
+                {icon ? (
+                  <img
+                    className={flag ? 'translate-lang-flag no-filter' : 'translate-lang-ai-icon'}
+                    src={icon}
+                    alt=""
+                    draggable={false}
+                  />
+                ) : (
+                  <span className="translate-lang-flag-placeholder" />
+                )}
+                <span>{t(lang.labelKey)}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 /**
  * 渲染截图设置页面
  * @returns 截图设置页面
  */
 export function ScreenshotSettingsPage(): ReactElement {
+  const { t } = useTranslation();
+  const [sourceLang, setSourceLang] = useState('auto');
+  const [targetLang, setTargetLang] = useState('en');
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api.storeRead(SCREENSHOT_TRANSLATE_SOURCE_LANG_STORE_KEY).then((value) => {
+      if (cancelled || typeof value !== 'string') return;
+      setSourceLang(value);
+    }).catch(() => {});
+    window.api.storeRead(SCREENSHOT_TRANSLATE_TARGET_LANG_STORE_KEY).then((value) => {
+      if (cancelled || typeof value !== 'string') return;
+      setTargetLang(value);
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSourceLangChange = (code: string): void => {
+    setSourceLang(code);
+    void window.api.storeWrite(SCREENSHOT_TRANSLATE_SOURCE_LANG_STORE_KEY, code);
+  };
+
+  const handleTargetLangChange = (code: string): void => {
+    setTargetLang(code);
+    void window.api.storeWrite(SCREENSHOT_TRANSLATE_TARGET_LANG_STORE_KEY, code);
+  };
+
   return (
     <div className="settings-screenshot-page-panel">
       <div className="settings-cards">
-        {/* TODO: 截图设置内容待实现 */}
+        <div className="settings-card">
+          <div className="settings-card-header">
+            <div className="settings-card-title">
+              {t('settings.app.screenshotSettings.translateTitle', { defaultValue: '截图翻译语言' })}
+            </div>
+            <div className="settings-card-subtitle">
+              {t('settings.app.screenshotSettings.translateHint', { defaultValue: '配置截图翻译的源语言和目标语言。' })}
+            </div>
+          </div>
+          <div className="settings-card-body">
+            <div className="translate-lang-row">
+              <TranslateLangDropdown
+                options={TRANSLATE_LANGUAGES}
+                value={sourceLang}
+                onChange={handleSourceLangChange}
+              />
+              <button
+                className="translate-swap-btn"
+                type="button"
+                onClick={() => {
+                  if (sourceLang === 'auto') return;
+                  const nextSource = targetLang;
+                  const nextTarget = sourceLang;
+                  handleSourceLangChange(nextSource);
+                  handleTargetLangChange(nextTarget);
+                }}
+                disabled={sourceLang === 'auto'}
+                title={t('maxExpand.toolbox.translate.swap')}
+              >
+                <img className="translate-swap-icon" src={SvgIcon.SWITCHING} alt="" draggable={false} />
+              </button>
+              <TranslateLangDropdown
+                options={TRANSLATE_TARGET_LANGUAGES}
+                value={targetLang}
+                onChange={handleTargetLangChange}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/states/maxExpand/components/setting/config/settingsTabConfig.ts
+++ b/src/renderer/components/states/maxExpand/components/setting/config/settingsTabConfig.ts
@@ -49,6 +49,8 @@ export const SETTINGS_OPEN_TAB_STORE_KEY = 'settings-open-tab';
 export const ISLAND_AUTO_DIM_ENABLED_STORE_KEY = 'island-auto-dim-enabled';
 export const ISLAND_AUTO_DIM_DELAY_STORE_KEY = 'island-auto-dim-delay';
 export const AUTO_HIDE_FULLSCREEN_WINDOWS_STORE_KEY = 'auto-hide-fullscreen-windows';
+export const SCREENSHOT_TRANSLATE_SOURCE_LANG_STORE_KEY = 'screenshot-translate-source-lang';
+export const SCREENSHOT_TRANSLATE_TARGET_LANG_STORE_KEY = 'screenshot-translate-target-lang';
 export const DEFAULT_AUTO_DIM_DELAY_SEC = 10;
 
 export type SettingsOpenTabIntent = 'update' | 'about-feedback' | 'user-orders' | 'user-info' | 'ai' | 'mail' | 'performance-monitor' | 'expand-layout';

--- a/src/renderer/components/states/maxExpand/components/setting/utils/settingsConfig.ts
+++ b/src/renderer/components/states/maxExpand/components/setting/utils/settingsConfig.ts
@@ -53,7 +53,7 @@ export const WEATHER_LOCATION_PRIORITY_OPTIONS: Array<{ value: WeatherLocationPr
 
 export const SETTINGS_TABS = ['index', 'app', 'network', 'mail', 'weather', 'music', 'ai', 'shortcut', 'user', 'update', 'pluginMarket', 'about'] as const;
 export type SettingsSidebarTabKey = (typeof SETTINGS_TABS)[number];
-export type AppSettingsPageKey = 'layout-preview' | 'expand-layout' | 'maxexpand-layout' | 'album' | 'hide-process-list' | 'position' | 'theme' | 'language' | 'behavior' | 'animation' | 'url-parser' | 'clipboard-history' | 'alarm' | 'break-reminder' | 'autostart' | 'sound' | 'notification' | 'performance' | 'performance-monitor';
+export type AppSettingsPageKey = 'layout-preview' | 'expand-layout' | 'maxexpand-layout' | 'album' | 'hide-process-list' | 'position' | 'theme' | 'language' | 'behavior' | 'animation' | 'url-parser' | 'clipboard-history' | 'alarm' | 'break-reminder' | 'autostart' | 'sound' | 'notification' | 'performance' | 'performance-monitor' | 'screenshot-settings';
 export type WeatherSettingsPageKey = 'location' | 'provider';
 export type MailSettingsPageKey = 'account' | 'imap' | 'preferences';
 export type AiSettingsPageKey = 'general' | 'r1pxc' | 'ollama';
@@ -83,6 +83,7 @@ export const SETTINGS_TAB_LABELS: Record<SettingsTabLabelKey, string> = {
   notification: '通知设置',
   performance: '性能设置',
   'performance-monitor': '性能监控',
+  'screenshot-settings': '截图设置',
   network: '网络配置',
   mail: '邮箱配置',
   weather: '天气配置',
@@ -122,6 +123,7 @@ export const SETTINGS_TAB_DESCRIPTIONS: Record<Exclude<SettingsTabLabelKey, 'ind
   notification: '配置灵动岛通知提醒与展示行为。',
   performance: '性能相关配置。',
   'performance-monitor': '性能监控展示与硬件状态配置。',
+  'screenshot-settings': '截图相关配置。',
   network: '请求超时与网络行为设置',
   mail: '配置 IMAP 收信参数',
   weather: '天气接口优先级设置',
@@ -172,6 +174,7 @@ export const SETTINGS_TAB_ICONS: Partial<Record<SettingsTabLabelKey, string>> = 
   notification: SvgIcon.NOTIFICATION,
   performance: SvgIcon.TASK_MANAGER,
   'performance-monitor': SvgIcon.TASK_MANAGER,
+  'screenshot-settings': SvgIcon.SCREENSHOT,
   pluginMarket: SvgIcon.PLUGIN,
 };
 
@@ -330,7 +333,7 @@ export function normalizeMaxExpandNavLayoutConfig(raw: unknown): MaxExpandNavLay
   return ordered;
 }
 
-export const APP_SETTINGS_PAGES: AppSettingsPageKey[] = ['layout-preview', 'expand-layout', 'maxexpand-layout', 'album', 'hide-process-list', 'position', 'theme', 'language', 'behavior', 'animation', 'url-parser', 'clipboard-history', 'alarm', 'break-reminder', 'autostart', 'sound', 'notification', 'performance', 'performance-monitor'];
+export const APP_SETTINGS_PAGES: AppSettingsPageKey[] = ['layout-preview', 'expand-layout', 'maxexpand-layout', 'album', 'hide-process-list', 'position', 'theme', 'language', 'behavior', 'animation', 'url-parser', 'clipboard-history', 'alarm', 'break-reminder', 'autostart', 'sound', 'notification', 'performance', 'performance-monitor', 'screenshot-settings'];
 export const WEATHER_SETTINGS_PAGES: WeatherSettingsPageKey[] = ['location', 'provider'];
 export const WEATHER_SETTINGS_PAGE_LABELS: Record<WeatherSettingsPageKey, string> = {
   location: '定位配置',
@@ -389,6 +392,7 @@ export const NAV_CARDS: NavCardDef[] = [
   { id: 'notification', label: SETTINGS_TAB_LABELS.notification, desc: SETTINGS_TAB_DESCRIPTIONS.notification, icon: SETTINGS_TAB_ICONS.notification, tab: 'app', appPage: 'notification' },
   { id: 'performance', label: SETTINGS_TAB_LABELS.performance, desc: SETTINGS_TAB_DESCRIPTIONS.performance, icon: SETTINGS_TAB_ICONS.performance, tab: 'app', appPage: 'performance' },
   { id: 'performance-monitor', label: SETTINGS_TAB_LABELS['performance-monitor'], desc: SETTINGS_TAB_DESCRIPTIONS['performance-monitor'], icon: SETTINGS_TAB_ICONS['performance-monitor'], tab: 'app', appPage: 'performance-monitor' },
+  { id: 'screenshot-settings', label: SETTINGS_TAB_LABELS['screenshot-settings'], desc: SETTINGS_TAB_DESCRIPTIONS['screenshot-settings'], icon: SETTINGS_TAB_ICONS['screenshot-settings'], tab: 'app', appPage: 'screenshot-settings' },
   { id: 'network', label: SETTINGS_TAB_LABELS.network, desc: SETTINGS_TAB_DESCRIPTIONS.network, icon: SETTINGS_TAB_ICONS.network, tab: 'network' },
   { id: 'mail', label: SETTINGS_TAB_LABELS.mail, desc: SETTINGS_TAB_DESCRIPTIONS.mail, icon: SETTINGS_TAB_ICONS.mail, tab: 'mail' },
   { id: 'weather', label: SETTINGS_TAB_LABELS.weather, desc: SETTINGS_TAB_DESCRIPTIONS.weather, icon: SETTINGS_TAB_ICONS.weather, tab: 'weather' },


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Add configurable screenshot translation languages in app settings and wire them through the capture translation flow.

New Features:
- Introduce a Screenshot settings page that lets users choose source and target languages for screenshot translation and persist these preferences.
- Add language selection dropdowns with flag icons and swap support for configuring screenshot translation source/target languages.

Enhancements:
- Update capture image translation IPC and service to accept configurable source and target languages, using stored preferences with sensible defaults.
- Extend app settings navigation, labels, and icons to include the new Screenshot settings page.