### PR TITLE
feat: 添加多端支付结果轮询功能并优化订单界面分页

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3463,7 +3463,7 @@
         "wechatHint": "Recommended: scan with WeChat",
         "alipayHint": "Recommended: scan with Alipay",
         "scanQrHint": "Please scan with WeChat to pay",
-        "scanQrSubhint": "After scanning, complete payment on your phone, then refresh status here",
+        "scanQrSubhint": "Complete payment on your phone after scanning. The result will update automatically.",
         "showQrCode": "Show QR Code",
         "hideQrCode": "Hide QR Code",
         "selectMethodHint": "Select a payment method above before creating an order.",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -3386,6 +3386,12 @@
           "loadFailed": "Failed to load orders",
           "closeFailed": "Failed to close order. Please try again later",
           "closeSuccess": "Order closed"
+        },
+        "pagination": {
+          "label": "Order history pagination",
+          "previous": "Previous",
+          "next": "Next",
+          "summary": "Page {{page}} / {{totalPages}}, {{total}} items"
         }
       },
       "pro": {

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3463,7 +3463,7 @@
         "wechatHint": "推荐使用微信扫码完成支付",
         "alipayHint": "推荐使用支付宝扫码完成支付",
         "scanQrHint": "请使用微信扫一扫完成支付",
-        "scanQrSubhint": "扫码后请在手机上完成支付，再回到此处刷新状态",
+        "scanQrSubhint": "扫码后请在手机上完成支付，支付结果将自动同步",
         "showQrCode": "显示二维码",
         "hideQrCode": "收起二维码",
         "selectMethodHint": "请选择上方支付方式后再创建订单。",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -3386,6 +3386,12 @@
           "loadFailed": "加载订单失败",
           "closeFailed": "关闭订单失败，请稍后重试",
           "closeSuccess": "订单已关闭"
+        },
+        "pagination": {
+          "label": "订单历史分页",
+          "previous": "上一页",
+          "next": "下一页",
+          "summary": "第 {{page}} / {{totalPages}} 页，共 {{total}} 条"
         }
       },
       "pro": {

--- a/src/renderer/api/user/test/userAccountApi.client.test.ts
+++ b/src/renderer/api/user/test/userAccountApi.client.test.ts
@@ -67,7 +67,7 @@ describe('userAccountApi.client', () => {
 
     it('uses production server', async () => {
       const mod = await import('../userAccountApi.client');
-      expect(mod.USER_ACCOUNT_API_BASE).toBe('https://server.pyisland.com/api');
+      expect(mod.USER_ACCOUNT_API_BASE).toBe('https://test.server.pyisland.com/api');
     });
   });
 
@@ -145,7 +145,7 @@ describe('userAccountApi.client', () => {
 
       expect(netFetchMock).toHaveBeenCalledOnce();
       const [url, opts] = netFetchMock.mock.calls[0];
-      expect(url).toBe('https://server.pyisland.com/api/v1/user/profile');
+      expect(url).toBe('https://test.server.pyisland.com/api/v1/user/profile');
       expect(opts.method).toBe('GET');
     });
 

--- a/src/renderer/api/user/test/userAccountApi.payment.test.ts
+++ b/src/renderer/api/user/test/userAccountApi.payment.test.ts
@@ -121,78 +121,67 @@ describe('userAccountApi.payment', () => {
   });
 
   describe('fetchUserPaymentOrders', () => {
-    it('sends GET to /v1/user/payment/orders with default limit 20', async () => {
+    it('sends GET to /v1/user/payment/orders with default page 1 and pageSize 5', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
       await fetchUserPaymentOrders('my-token');
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=20', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=1&pageSize=5', {
         method: 'GET',
         auth: 'my-token',
       });
     });
 
-    it('uses provided limit when within range', async () => {
+    it('uses provided page and pageSize', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
-      await fetchUserPaymentOrders('my-token', 10);
+      await fetchUserPaymentOrders('my-token', 2, 10);
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=10', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=2&pageSize=10', {
         method: 'GET',
         auth: 'my-token',
       });
     });
 
-    it('clamps limit to max 50', async () => {
+    it('clamps pageSize to max 50', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
-      await fetchUserPaymentOrders('my-token', 100);
+      await fetchUserPaymentOrders('my-token', 1, 100);
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=50', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=1&pageSize=50', {
         method: 'GET',
         auth: 'my-token',
       });
     });
 
-    it('clamps limit to min 1', async () => {
+    it('falls back to default pageSize for falsy input (0)', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
-      await fetchUserPaymentOrders('my-token', 1);
+      await fetchUserPaymentOrders('my-token', 1, 0);
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=1', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=1&pageSize=5', {
         method: 'GET',
         auth: 'my-token',
       });
     });
 
-    it('falls back to default 20 for falsy limit (0)', async () => {
+    it('clamps page to min 1', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
-      await fetchUserPaymentOrders('my-token', 0);
+      await fetchUserPaymentOrders('my-token', 0, 5);
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=20', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=1&pageSize=5', {
         method: 'GET',
         auth: 'my-token',
       });
     });
 
-    it('clamps negative limit to min 1', async () => {
+    it('falls back to defaults for NaN inputs', async () => {
       mockRequest.mockResolvedValueOnce(okResult);
 
-      await fetchUserPaymentOrders('my-token', -5);
+      await fetchUserPaymentOrders('my-token', Number.NaN, Number.NaN);
 
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=1', {
-        method: 'GET',
-        auth: 'my-token',
-      });
-    });
-
-    it('falls back to default 20 for NaN input', async () => {
-      mockRequest.mockResolvedValueOnce(okResult);
-
-      await fetchUserPaymentOrders('my-token', Number.NaN);
-
-      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?limit=20', {
+      expect(mockRequest).toHaveBeenCalledWith('/v1/user/payment/orders?page=1&pageSize=5', {
         method: 'GET',
         auth: 'my-token',
       });

--- a/src/renderer/api/user/userAccountApi.client.ts
+++ b/src/renderer/api/user/userAccountApi.client.ts
@@ -30,7 +30,7 @@ import type { InternalRequestInit } from './types/InternalRequestInit';
 
 export type { InternalRequestInit };
 
-export const USER_ACCOUNT_API_BASE = 'https://server.pyisland.com/api';
+export const USER_ACCOUNT_API_BASE = 'https://test.server.pyisland.com/api';
 
 /** GitHub OAuth 固定使用生产域名 */
 export const GITHUB_API_BASE = 'https://server.pyisland.com/api';

--- a/src/renderer/api/user/userAccountApi.payment.ts
+++ b/src/renderer/api/user/userAccountApi.payment.ts
@@ -34,6 +34,9 @@ import type {
 import type { UserPaymentCreateChannel } from './types/UserPayment';
 import type { AgentBalanceData } from './types/UserPayment';
 
+/** 订单列表默认每页数量 */
+export const PAYMENT_ORDERS_DEFAULT_PAGE_SIZE = 5;
+
 /** 订单分页结果 */
 export interface PaymentOrderPage {
   items: UserPaymentOrderData[];
@@ -114,10 +117,10 @@ export function fetchPaymentOrder(
 export function fetchUserPaymentOrders(
   token: string,
   page = 1,
-  pageSize = 5,
+  pageSize = PAYMENT_ORDERS_DEFAULT_PAGE_SIZE,
 ): Promise<UserAccountResult<PaymentOrderPage>> {
   const normalizedPage = Math.max(1, Math.floor(Number(page) || 1));
-  const normalizedPageSize = Math.max(1, Math.min(Math.floor(Number(pageSize) || 5), 50));
+  const normalizedPageSize = Math.max(1, Math.min(Math.floor(Number(pageSize) || PAYMENT_ORDERS_DEFAULT_PAGE_SIZE), 50));
   return request<PaymentOrderPage>(
     `/v1/user/payment/orders?page=${normalizedPage}&pageSize=${normalizedPageSize}`,
     {

--- a/src/renderer/api/user/userAccountApi.payment.ts
+++ b/src/renderer/api/user/userAccountApi.payment.ts
@@ -34,6 +34,15 @@ import type {
 import type { UserPaymentCreateChannel } from './types/UserPayment';
 import type { AgentBalanceData } from './types/UserPayment';
 
+/** 订单分页结果 */
+export interface PaymentOrderPage {
+  items: UserPaymentOrderData[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
 export type { UserPaymentCreateChannel, AgentBalanceData };
 
 /**
@@ -96,20 +105,26 @@ export function fetchPaymentOrder(
 }
 
 /**
- * 查询当前用户支付订单列表。
+ * 查询当前用户支付订单列表（分页）。
  * @param token - 用户 token。
- * @param limit - 返回数量上限。
- * @returns 支付订单列表。
+ * @param page - 页码，默认 1。
+ * @param pageSize - 每页数量，默认 5，最大 50。
+ * @returns 分页的订单列表。
  */
 export function fetchUserPaymentOrders(
   token: string,
-  limit = 20,
-): Promise<UserAccountResult<UserPaymentOrderData[]>> {
-  const normalizedLimit = Math.max(1, Math.min(Number(limit) || 20, 50));
-  return request<UserPaymentOrderData[]>(`/v1/user/payment/orders?limit=${normalizedLimit}`, {
-    method: 'GET',
-    auth: token,
-  });
+  page = 1,
+  pageSize = 5,
+): Promise<UserAccountResult<PaymentOrderPage>> {
+  const normalizedPage = Math.max(1, Math.floor(Number(page) || 1));
+  const normalizedPageSize = Math.max(1, Math.min(Math.floor(Number(pageSize) || 5), 50));
+  return request<PaymentOrderPage>(
+    `/v1/user/payment/orders?page=${normalizedPage}&pageSize=${normalizedPageSize}`,
+    {
+      method: 'GET',
+      auth: token,
+    },
+  );
 }
 
 /**

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -46,8 +46,8 @@ import {
   uploadUserAvatar,
   type ImageTranslationHistoryItem,
   type OAuthBindingItem,
-  type PaymentOrderPage,
   type UserPaymentOrderData,
+  PAYMENT_ORDERS_DEFAULT_PAGE_SIZE,
 } from '../../../../../../../api/user/userAccountApi';
 import { runSliderCaptcha } from '../../../../../../../utils/sliderCaptcha';
 import useIslandStore from '../../../../../../../store/slices';
@@ -231,7 +231,6 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [ordersPage, setOrdersPage] = useState(1);
   const [ordersTotal, setOrdersTotal] = useState(0);
   const [ordersTotalPages, setOrdersTotalPages] = useState(0);
-  const ORDERS_PAGE_SIZE = 5;
   const [orderActionOutTradeNo, setOrderActionOutTradeNo] = useState('');
   const [rechargeSelected, setRechargeSelected] = useState<number | null>(null);
   const [rechargeCustomValue, setRechargeCustomValue] = useState('');
@@ -669,7 +668,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
     setLoadingUserOrders(true);
     setOrdersFeedback(null);
-    const result = await fetchUserPaymentOrders(token, page, ORDERS_PAGE_SIZE);
+    const result = await fetchUserPaymentOrders(token, page, PAYMENT_ORDERS_DEFAULT_PAGE_SIZE);
     setLoadingUserOrders(false);
     if (!result.ok || !result.data || !Array.isArray(result.data.items)) {
       if (result.code === 401 || result.code === 4011) {

--- a/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/user/UserSettingsSection.tsx
@@ -46,6 +46,7 @@ import {
   uploadUserAvatar,
   type ImageTranslationHistoryItem,
   type OAuthBindingItem,
+  type PaymentOrderPage,
   type UserPaymentOrderData,
 } from '../../../../../../../api/user/userAccountApi';
 import { runSliderCaptcha } from '../../../../../../../utils/sliderCaptcha';
@@ -227,6 +228,10 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
   const [userOrders, setUserOrders] = useState<UserPaymentOrderData[]>([]);
   const [loadingUserOrders, setLoadingUserOrders] = useState(false);
   const [ordersFeedback, setOrdersFeedback] = useState<Feedback | null>(null);
+  const [ordersPage, setOrdersPage] = useState(1);
+  const [ordersTotal, setOrdersTotal] = useState(0);
+  const [ordersTotalPages, setOrdersTotalPages] = useState(0);
+  const ORDERS_PAGE_SIZE = 5;
   const [orderActionOutTradeNo, setOrderActionOutTradeNo] = useState('');
   const [rechargeSelected, setRechargeSelected] = useState<number | null>(null);
   const [rechargeCustomValue, setRechargeCustomValue] = useState('');
@@ -653,16 +658,20 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     }
   };
 
-  const loadUserOrders = useCallback(async (): Promise<void> => {
+  const loadUserOrders = useCallback(async (page: number): Promise<void> => {
     if (!token) {
       setUserOrders([]);
+      setOrdersPage(1);
+      setOrdersTotal(0);
+      setOrdersTotalPages(0);
       setLoadingUserOrders(false);
       return;
     }
     setLoadingUserOrders(true);
-    const result = await fetchUserPaymentOrders(token, 20);
+    setOrdersFeedback(null);
+    const result = await fetchUserPaymentOrders(token, page, ORDERS_PAGE_SIZE);
     setLoadingUserOrders(false);
-    if (!result.ok || !Array.isArray(result.data)) {
+    if (!result.ok || !result.data || !Array.isArray(result.data.items)) {
       if (result.code === 401 || result.code === 4011) {
         resetToLoggedOut();
         return;
@@ -670,8 +679,11 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       setOrdersFeedback({ type: 'error', text: result.message || t('settings.user.orders.feedback.loadFailed', { defaultValue: '加载订单失败' }) });
       return;
     }
-    setUserOrders(result.data);
-    const hasPaidOrder = result.data.some((order) => String(order?.status || '').toUpperCase() === 'SUCCESS');
+    setUserOrders(result.data.items);
+    setOrdersPage(result.data.page);
+    setOrdersTotal(result.data.total);
+    setOrdersTotalPages(result.data.totalPages);
+    const hasPaidOrder = result.data.items.some((order) => String(order?.status || '').toUpperCase() === 'SUCCESS');
     if (hasPaidOrder) {
       await loadRemoteProfile(token);
     }
@@ -788,8 +800,8 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
     if (userProfilePage !== 'orders' || !token) {
       return;
     }
-    void loadUserOrders();
-  }, [loadUserOrders, token, userProfilePage]);
+    void loadUserOrders(ordersPage);
+  }, [loadUserOrders, ordersPage, token, userProfilePage]);
 
   useEffect(() => {
     if (userProfilePage !== 'image-translation' || !token) {
@@ -1178,7 +1190,11 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
       return;
     }
     setOrdersFeedback({ type: 'success', text: t('settings.user.orders.feedback.closeSuccess', { defaultValue: '订单已关闭' }) });
-    await loadUserOrders();
+    if (userOrders.length === 1 && ordersPage > 1) {
+      setOrdersPage((current) => Math.max(1, current - 1));
+      return;
+    }
+    await loadUserOrders(ordersPage);
   };
 
   const renderOrdersPage = (): ReactElement => (
@@ -1193,7 +1209,7 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
               type="button"
               className="settings-user-secondary-btn settings-user-orders-refresh-btn"
               disabled={loadingUserOrders || !!orderActionOutTradeNo}
-              onClick={() => void loadUserOrders()}
+              onClick={() => void loadUserOrders(ordersPage)}
             >
               {loadingUserOrders
                 ? (
@@ -1283,6 +1299,35 @@ export function UserSettingsSection({ initialProfilePage = 'info' }: UserSetting
             </div>
           );
         })}
+
+        {ordersTotalPages > 0 ? (
+          <nav className="settings-plugin-market-pagination settings-user-orders-pagination" aria-label={t('settings.user.orders.pagination.label', { defaultValue: '订单历史分页' })}>
+            <button
+              type="button"
+              className="settings-hotkey-btn"
+              disabled={loadingUserOrders || ordersPage <= 1}
+              onClick={() => setOrdersPage((current) => Math.max(1, current - 1))}
+            >
+              {t('settings.user.orders.pagination.previous', { defaultValue: '上一页' })}
+            </button>
+            <span className="settings-plugin-market-pagination-text settings-user-orders-pagination-summary">
+              {t('settings.user.orders.pagination.summary', {
+                defaultValue: '第 {{page}} / {{totalPages}} 页，共 {{total}} 条',
+                page: ordersPage,
+                totalPages: ordersTotalPages,
+                total: ordersTotal,
+              })}
+            </span>
+            <button
+              type="button"
+              className="settings-hotkey-btn"
+              disabled={loadingUserOrders || ordersPage >= ordersTotalPages}
+              onClick={() => setOrdersPage((current) => Math.min(ordersTotalPages, current + 1))}
+            >
+              {t('settings.user.orders.pagination.next', { defaultValue: '下一页' })}
+            </button>
+          </nav>
+        ) : null}
     </div>
   );
 

--- a/src/renderer/components/states/payment/PaymentContent.tsx
+++ b/src/renderer/components/states/payment/PaymentContent.tsx
@@ -31,8 +31,6 @@ import useIslandStore from '../../../store/slices';
 import {
   createProMonthOrder,
   createAgentRechargeOrder,
-  fetchPaymentOrder,
-  type UserPaymentOrderData,
 } from '../../../api/user/userAccountApi';
 import { runSliderCaptcha } from '../../../utils/sliderCaptcha';
 import { readLocalProfile, readLocalToken } from '../../../utils/userAccount';
@@ -40,6 +38,7 @@ import { SETTINGS_OPEN_TAB_STORE_KEY, EMAIL_PATTERN, type PaymentMethod } from '
 import { formatDateOnly } from './utils/formatDateOnly';
 import { usePaymentChannels } from './hooks/usePaymentChannels';
 import { usePaymentStatus } from './hooks/usePaymentStatus';
+import { usePaymentStatusPolling } from './hooks/usePaymentStatusPolling';
 import { useMethodValidation } from './hooks/useMethodValidation';
 import { PaymentMethodSelector } from './components/PaymentMethodSelector';
 import { PaymentOrderForm } from './components/PaymentOrderForm';
@@ -62,8 +61,12 @@ export function PaymentContent(): ReactElement {
   const [subscriptionPeriod, setSubscriptionPeriod] = useState('');
   const [feedback, setFeedback] = useState('');
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
-  const [isRefreshingStatus, setIsRefreshingStatus] = useState(false);
-  const [pendingOrder, setPendingOrder] = useState<UserPaymentOrderData | null>(null);
+  const {
+    pendingOrder,
+    setPendingOrder,
+    isRefreshingStatus,
+    refreshStatus,
+  } = usePaymentStatusPolling({ onManualFeedback: setFeedback });
 
   const { wechatEnabled, alipayEnabled, priceLabel } = usePaymentChannels(isRechargeMode, rechargeAmountFen);
   const {
@@ -170,26 +173,8 @@ export function PaymentContent(): ReactElement {
     setMaxExpand();
   };
 
-  const handleRefreshPaymentStatus = async (): Promise<void> => {
-    if (!pendingOrder || !pendingOrder.outTradeNo || isRefreshingStatus) return;
-    const token = readLocalToken();
-    if (!token) {
-      setFeedback(t('settings.user.payment.loginRequired', { defaultValue: '登录状态已失效，请重新登录后再试。' }));
-      return;
-    }
-    try {
-      setIsRefreshingStatus(true);
-      const result = await fetchPaymentOrder(token, pendingOrder.outTradeNo);
-      if (!result.ok || !result.data) {
-        setFeedback(result.message || t('settings.user.payment.refreshStatusFailed', { defaultValue: '刷新支付状态失败，请稍后重试。' }));
-        return;
-      }
-      setPendingOrder(result.data);
-      if (result.data.expireAt) setOrderExpireAt(result.data.expireAt);
-      setFeedback('');
-    } finally {
-      setIsRefreshingStatus(false);
-    }
+  const handleRefreshPaymentStatus = (): void => {
+    void refreshStatus();
   };
 
   const handleFillAccountEmail = (): void => {

--- a/src/renderer/components/states/payment/components/PaymentPendingOrder.tsx
+++ b/src/renderer/components/states/payment/components/PaymentPendingOrder.tsx
@@ -143,7 +143,7 @@ export function PaymentPendingOrder({
                 {t('settings.user.payment.scanQrHint', { defaultValue: '请使用微信扫一扫完成支付' })}
               </div>
               <div className="payment-qr-subhint">
-                {t('settings.user.payment.scanQrSubhint', { defaultValue: '扫码后请在手机上完成支付，再回到此处刷新状态' })}
+                {t('settings.user.payment.scanQrSubhint', { defaultValue: '扫码后请在手机上完成支付，支付结果将自动同步' })}
               </div>
             </div>
           ) : null}

--- a/src/renderer/components/states/payment/hooks/usePaymentStatusPolling.test.ts
+++ b/src/renderer/components/states/payment/hooks/usePaymentStatusPolling.test.ts
@@ -1,0 +1,67 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file usePaymentStatusPolling.test.ts
+ * @description 支付订单自动轮询终止条件测试
+ * @author 鸡哥
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { UserPaymentOrderData } from '../../../../api/user/userAccountApi';
+import {
+  PAYMENT_EXPIRE_GRACE_MS,
+  shouldPollPaymentOrder,
+} from './usePaymentStatusPolling';
+
+const NOW = Date.parse('2026-08-02T12:00:00.000Z');
+
+function createOrder(overrides: Partial<UserPaymentOrderData> = {}): UserPaymentOrderData {
+  return {
+    outTradeNo: 'ORDER-1',
+    productCode: 'PRO_MONTH',
+    amountFen: 1500,
+    currency: 'CNY',
+    status: 'PAYING',
+    channel: 'WECHAT',
+    expireAt: new Date(NOW + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('shouldPollPaymentOrder', () => {
+  it('continues polling a paying order before expiration', () => {
+    expect(shouldPollPaymentOrder(createOrder(), NOW)).toBe(true);
+  });
+
+  it.each(['SUCCESS', 'CLOSED', 'FAILED'])('stops polling terminal status %s', (status) => {
+    expect(shouldPollPaymentOrder(createOrder({ status }), NOW)).toBe(false);
+  });
+
+  it('stops after the expiration grace period', () => {
+    const expireAt = new Date(NOW - PAYMENT_EXPIRE_GRACE_MS - 1).toISOString();
+    expect(shouldPollPaymentOrder(createOrder({ expireAt }), NOW)).toBe(false);
+  });
+
+  it('keeps polling when the server omits or returns an invalid expiration', () => {
+    expect(shouldPollPaymentOrder(createOrder({ expireAt: undefined }), NOW)).toBe(true);
+    expect(shouldPollPaymentOrder(createOrder({ expireAt: 'invalid' }), NOW)).toBe(true);
+  });
+});

--- a/src/renderer/components/states/payment/hooks/usePaymentStatusPolling.ts
+++ b/src/renderer/components/states/payment/hooks/usePaymentStatusPolling.ts
@@ -1,0 +1,146 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file usePaymentStatusPolling.ts
+ * @description 支付订单状态轮询与手动刷新 Hook
+ * @author 鸡哥
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  fetchPaymentOrder,
+  type UserPaymentOrderData,
+} from '../../../../api/user/userAccountApi';
+import { readLocalToken } from '../../../../utils/userAccount';
+
+export const PAYMENT_POLL_INTERVAL_MS = 3_000;
+export const PAYMENT_EXPIRE_GRACE_MS = 60_000;
+
+interface UsePaymentStatusPollingOptions {
+  onManualFeedback: (message: string) => void;
+}
+
+interface UsePaymentStatusPollingResult {
+  pendingOrder: UserPaymentOrderData | null;
+  setPendingOrder: Dispatch<SetStateAction<UserPaymentOrderData | null>>;
+  isRefreshingStatus: boolean;
+  refreshStatus: () => Promise<void>;
+}
+
+/**
+ * 判断订单是否仍需自动轮询。
+ *
+ * @param order - 当前支付订单
+ * @param now - 当前时间戳，默认使用系统时间
+ * @returns 订单处于待支付且未超过到期宽限时返回 true
+ */
+export function shouldPollPaymentOrder(
+  order: UserPaymentOrderData | null,
+  now = Date.now(),
+): boolean {
+  if (!order || String(order.status || '').toUpperCase() !== 'PAYING') return false;
+  if (!order.expireAt) return true;
+  const expireAt = new Date(order.expireAt).getTime();
+  return !Number.isFinite(expireAt) || now <= expireAt + PAYMENT_EXPIRE_GRACE_MS;
+}
+
+/**
+ * 管理待支付订单并在支付页存活期间自动同步其状态。
+ *
+ * @param options - 手动刷新结果回调
+ * @returns 当前订单、订单更新入口与手动刷新状态
+ */
+export function usePaymentStatusPolling({
+  onManualFeedback,
+}: UsePaymentStatusPollingOptions): UsePaymentStatusPollingResult {
+  const { t } = useTranslation();
+  const [pendingOrder, setPendingOrder] = useState<UserPaymentOrderData | null>(null);
+  const [isRefreshingStatus, setIsRefreshingStatus] = useState(false);
+  const requestInFlightRef = useRef(false);
+
+  const queryOrder = useCallback(async (
+    outTradeNo: string,
+    manual: boolean,
+  ): Promise<UserPaymentOrderData | null> => {
+    if (requestInFlightRef.current) return null;
+    const token = readLocalToken();
+    if (!token) {
+      if (manual) {
+        onManualFeedback(t('settings.user.payment.loginRequired', { defaultValue: '登录状态已失效，请重新登录后再试。' }));
+      }
+      return null;
+    }
+
+    requestInFlightRef.current = true;
+    if (manual) setIsRefreshingStatus(true);
+    try {
+      const result = await fetchPaymentOrder(token, outTradeNo);
+      if (!result.ok || !result.data) {
+        if (manual) {
+          onManualFeedback(result.message || t('settings.user.payment.refreshStatusFailed', { defaultValue: '刷新支付状态失败，请稍后重试。' }));
+        }
+        return null;
+      }
+      setPendingOrder((current) => current?.outTradeNo === outTradeNo ? result.data ?? current : current);
+      if (manual) onManualFeedback('');
+      return result.data;
+    } finally {
+      requestInFlightRef.current = false;
+      if (manual) setIsRefreshingStatus(false);
+    }
+  }, [onManualFeedback, t]);
+
+  useEffect(() => {
+    if (!shouldPollPaymentOrder(pendingOrder)) return undefined;
+    const outTradeNo = pendingOrder.outTradeNo;
+    let cancelled = false;
+    let timerId: ReturnType<typeof setTimeout>;
+
+    const poll = async (): Promise<void> => {
+      const result = await queryOrder(outTradeNo, false);
+      if (cancelled) return;
+      const nextOrder = result ?? pendingOrder;
+      if (shouldPollPaymentOrder(nextOrder)) {
+        timerId = setTimeout(poll, PAYMENT_POLL_INTERVAL_MS);
+      }
+    };
+
+    timerId = setTimeout(poll, PAYMENT_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timerId);
+    };
+  }, [pendingOrder, queryOrder]);
+
+  const refreshStatus = useCallback(async (): Promise<void> => {
+    if (!pendingOrder?.outTradeNo) return;
+    await queryOrder(pendingOrder.outTradeNo, true);
+  }, [pendingOrder, queryOrder]);
+
+  return {
+    pendingOrder,
+    setPendingOrder,
+    isRefreshingStatus,
+    refreshStatus,
+  };
+}


### PR DESCRIPTION
## Verification

- [x] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Introduce automatic payment status polling and paginate user payment order history, updating API contracts and environment configuration accordingly.

New Features:
- Add a payment status polling hook to automatically synchronize pending order status across devices and support manual refresh with unified feedback.
- Paginate the user payment orders view with page navigation and summary metadata using a new paginated PaymentOrderPage API response.

Enhancements:
- Refactor fetchUserPaymentOrders API to accept page and pageSize and return paginated results, updating consumers and related tests.
- Adjust payment UI copy to reflect automatic synchronization of QR-based payments instead of manual status refresh.

Tests:
- Extend payment orders API tests for the new pagination parameters and clamping behavior.
- Add unit tests for payment status polling termination conditions based on order status and expiration.
- Update user account API client tests to assert the new base URL.

Chores:
- Point USER_ACCOUNT_API_BASE to the test server domain for the renderer client and align tests with the new endpoint.