### PR TITLE
feat: 添加新的跑马灯律动模式和振幅模式和对应的配置项

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -2306,10 +2306,11 @@
         "musicOuterGlowTitle": "Music Outer Glow Effect",
         "musicOuterGlowHint": "Control the marquee/glow animation around the album cover while music is playing.",
         "musicOuterGlowToggle": "Enable outer glow marquee effect while music is playing",
-        "musicMarqueeModeHint": "Rhythm mode intensifies the marquee with the beat of the current audio",
+        "musicMarqueeModeHint": "Rhythm mode flashes on the beat; amplitude mode adjusts inward motion from each sample's strength",
         "musicMarqueeModeOptions": {
           "normal": "Normal",
-          "rhythm": "Rhythm"
+          "rhythm": "Rhythm",
+          "amplitude": "Amplitude"
         },
         "windowControlsTitle": "Standalone Window Controls Style",
         "windowControlsHint": "When enabled, the top-right controls in standalone window use macOS-style traffic-light dots",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -2306,6 +2306,11 @@
         "musicOuterGlowTitle": "Music Outer Glow Effect",
         "musicOuterGlowHint": "Control the marquee/glow animation around the album cover while music is playing.",
         "musicOuterGlowToggle": "Enable outer glow marquee effect while music is playing",
+        "musicMarqueeModeHint": "Rhythm mode intensifies the marquee with the beat of the current audio",
+        "musicMarqueeModeOptions": {
+          "normal": "Normal",
+          "rhythm": "Rhythm"
+        },
         "windowControlsTitle": "Standalone Window Controls Style",
         "windowControlsHint": "When enabled, the top-right controls in standalone window use macOS-style traffic-light dots",
         "windowControlsMacToggle": "Use Mac-style window controls",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -2306,6 +2306,7 @@
         "musicOuterGlowTitle": "Music Outer Glow Effect",
         "musicOuterGlowHint": "Control the marquee/glow animation around the album cover while music is playing.",
         "musicOuterGlowToggle": "Enable outer glow marquee effect while music is playing",
+        "musicMarqueeModeTitle": "Marquee Mode",
         "musicMarqueeModeHint": "Rhythm mode flashes on the beat; amplitude mode adjusts inward motion from each sample's strength",
         "musicMarqueeModeOptions": {
           "normal": "Normal",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -2306,6 +2306,11 @@
         "musicOuterGlowTitle": "音乐外光圈特效",
         "musicOuterGlowHint": "控制歌曲播放时专辑封面外圈的跑马灯/光晕动态效果。",
         "musicOuterGlowToggle": "启用歌曲播放外光圈跑马灯特效",
+        "musicMarqueeModeHint": "律动模式会让跑马灯跟随当前音频鼓点增强闪烁",
+        "musicMarqueeModeOptions": {
+          "normal": "普通模式",
+          "rhythm": "律动模式"
+        },
         "windowControlsTitle": "独立窗口控制按钮样式",
         "windowControlsHint": "启用后，独立窗口右上角将显示 macOS 风格三色圆点控制按钮",
         "windowControlsMacToggle": "使用 Mac 风格窗口控制按钮",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -2306,6 +2306,7 @@
         "musicOuterGlowTitle": "音乐外光圈特效",
         "musicOuterGlowHint": "控制歌曲播放时专辑封面外圈的跑马灯/光晕动态效果。",
         "musicOuterGlowToggle": "启用歌曲播放外光圈跑马灯特效",
+        "musicMarqueeModeTitle": "跑马灯模式",
         "musicMarqueeModeHint": "律动模式按节拍闪烁，振幅模式根据采样强度调整向内振动幅度",
         "musicMarqueeModeOptions": {
           "normal": "普通模式",

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -2306,10 +2306,11 @@
         "musicOuterGlowTitle": "音乐外光圈特效",
         "musicOuterGlowHint": "控制歌曲播放时专辑封面外圈的跑马灯/光晕动态效果。",
         "musicOuterGlowToggle": "启用歌曲播放外光圈跑马灯特效",
-        "musicMarqueeModeHint": "律动模式会让跑马灯跟随当前音频鼓点增强闪烁",
+        "musicMarqueeModeHint": "律动模式按节拍闪烁，振幅模式根据采样强度调整向内振动幅度",
         "musicMarqueeModeOptions": {
           "normal": "普通模式",
-          "rhythm": "律动模式"
+          "rhythm": "律动模式",
+          "amplitude": "振幅模式"
         },
         "windowControlsTitle": "独立窗口控制按钮样式",
         "windowControlsHint": "启用后，独立窗口右上角将显示 macOS 风格三色圆点控制按钮",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,6 +76,7 @@ import { createExternalAgentWatcher } from './system/externalAgentWatcher';
 import { createClaudeCodeStatusService } from './system/claudeCodeStatusService';
 import { createCodexStatusService } from './system/codexStatusService';
 import { play, pause, next } from '@eisland/windows-smtc-helper';
+import * as musicBeatAnalyzer from '@eisland/windows-volume-analyzer';
 import {
   queryFocusedWindow,
   queryOpenWindowsWithIcons,
@@ -141,7 +142,33 @@ let mainWindow: BrowserWindow | null = null;
 let agentVoiceInputWindow: BrowserWindow | null = null;
 let cliGlowWindow: BrowserWindow | null = null;
 let cachedFullscreenDetector: { isAnyFullscreenWindow: () => boolean } | null | undefined;
+let musicBeatProcessId: number | null = null;
 
+function startMusicBeatAnalyzer(): boolean {
+  try {
+    const processes = musicBeatAnalyzer.getPlayingProcesses(true);
+    const target = processes[0];
+    if (!target) return false;
+    if (musicBeatProcessId !== target.processId) {
+      musicBeatAnalyzer.stop();
+      musicBeatProcessId = target.processId;
+      const result = musicBeatAnalyzer.start(target.processId, true);
+      if (!result.success) {
+        musicBeatProcessId = null;
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    musicBeatProcessId = null;
+    return false;
+  }
+}
+
+function stopMusicBeatAnalyzer(): void {
+  musicBeatAnalyzer.stop();
+  musicBeatProcessId = null;
+}
 function detectAnyFullscreenWindow(): boolean {
   if (process.platform !== 'win32') return false;
   if (cachedFullscreenDetector === undefined) {
@@ -621,6 +648,9 @@ function registerIpcHandlers(): void {
     },
     sanitizeSmtcUnsubscribeMs,
     detectAllSources: smtcService.detectAllSources,
+    getMusicBeat: () => musicBeatAnalyzer.getResult(),
+    startMusicBeat: startMusicBeatAnalyzer,
+    stopMusicBeat: stopMusicBeatAnalyzer,
   });
 
   // ===== 歌曲设置 IPC =====

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -588,6 +588,7 @@ function registerIpcHandlers(): void {
     getCurrentDeviceId: smtcService.getCurrentDeviceId,
     setCurrentDeviceId: smtcService.setCurrentDeviceId,
     getSmtcSessionRuntime: smtcService.getSmtcSessionRuntime,
+    onSourceSwitchAccepted: startMusicBeatAnalyzer,
   });
 
   const writeMainLog = createSessionMainLogger();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,6 +70,7 @@ import { openStandaloneWindow } from './window/standaloneWindow';
 import { showSplashWindow, closeSplashWindow } from './window/splashWindow';
 import { showGuideWindow } from './window/guideWindow';
 import { createSmtcService } from './music/smtcService';
+import { resolveMusicAudioProcess } from './music/musicBeatSource';
 import { setSmtcAccessor } from './music/smtcAccessor';
 import { createAutoHideWatcher } from './system/autoHideWatcher';
 import { createExternalAgentWatcher } from './system/externalAgentWatcher';
@@ -143,24 +144,37 @@ let agentVoiceInputWindow: BrowserWindow | null = null;
 let cliGlowWindow: BrowserWindow | null = null;
 let cachedFullscreenDetector: { isAnyFullscreenWindow: () => boolean } | null | undefined;
 let musicBeatProcessId: number | null = null;
+let musicBeatSourceAppId = '';
 
 function startMusicBeatAnalyzer(): boolean {
   try {
-    const processes = musicBeatAnalyzer.getPlayingProcesses(true);
-    const target = processes[0];
-    if (!target) return false;
-    if (musicBeatProcessId !== target.processId) {
-      musicBeatAnalyzer.stop();
-      musicBeatProcessId = target.processId;
-      const result = musicBeatAnalyzer.start(target.processId, true);
-      if (!result.success) {
-        musicBeatProcessId = null;
-        return false;
-      }
+    const sourceAppId = smtcService.getCurrentDeviceId();
+    if (!sourceAppId) return false;
+    const analyzerStatus = musicBeatAnalyzer.getStatus();
+    if (musicBeatSourceAppId === sourceAppId && musicBeatProcessId !== null && analyzerStatus.isRunning) {
+      return true;
     }
+
+    const processes = musicBeatAnalyzer.getPlayingProcesses(true);
+    const target = resolveMusicAudioProcess(sourceAppId, processes);
+    if (!target) {
+      stopMusicBeatAnalyzer();
+      return false;
+    }
+
+    musicBeatAnalyzer.stop();
+    const result = musicBeatAnalyzer.start(target.processId, true);
+    if (!result.success) {
+      musicBeatProcessId = null;
+      musicBeatSourceAppId = '';
+      return false;
+    }
+    musicBeatProcessId = target.processId;
+    musicBeatSourceAppId = sourceAppId;
     return true;
   } catch {
     musicBeatProcessId = null;
+    musicBeatSourceAppId = '';
     return false;
   }
 }
@@ -168,6 +182,7 @@ function startMusicBeatAnalyzer(): boolean {
 function stopMusicBeatAnalyzer(): void {
   musicBeatAnalyzer.stop();
   musicBeatProcessId = null;
+  musicBeatSourceAppId = '';
 }
 function detectAnyFullscreenWindow(): boolean {
   if (process.platform !== 'win32') return false;
@@ -648,7 +663,10 @@ function registerIpcHandlers(): void {
     },
     sanitizeSmtcUnsubscribeMs,
     detectAllSources: smtcService.detectAllSources,
-    getMusicBeat: () => musicBeatAnalyzer.getResult(),
+    getMusicBeat: () => {
+      startMusicBeatAnalyzer();
+      return musicBeatAnalyzer.getResult();
+    },
     startMusicBeat: startMusicBeatAnalyzer,
     stopMusicBeat: stopMusicBeatAnalyzer,
   });

--- a/src/main/ipc/media/media.ts
+++ b/src/main/ipc/media/media.ts
@@ -44,6 +44,8 @@ interface RegisterMediaIpcHandlersOptions {
   getCurrentDeviceId: () => string;
   setCurrentDeviceId: (id: string) => void;
   getSmtcSessionRuntime: () => Map<string, MediaSessionRuntimeEntry> | null;
+  /** 用户主动切换播放源后触发，用于重启进程音频监听等后置逻辑 */
+  onSourceSwitchAccepted?: () => void;
 }
 
 /**
@@ -87,6 +89,7 @@ export function registerMediaIpcHandlers(options: RegisterMediaIpcHandlersOption
           win.webContents.send('nowplaying:info', payload);
         }
       });
+      options.onSourceSwitchAccepted?.();
     }
   });
 

--- a/src/main/ipc/media/music.ts
+++ b/src/main/ipc/media/music.ts
@@ -52,6 +52,9 @@ interface RegisterMusicIpcHandlersOptions {
   setSmtcUnsubscribeMs: (value: number) => void;
   sanitizeSmtcUnsubscribeMs: (value: unknown) => number;
   detectAllSources: () => Promise<Array<{ sourceAppId: string; isPlaying: boolean; hasTitle: boolean; thumbnail: string | null }>>;
+  getMusicBeat: () => unknown;
+  startMusicBeat: () => boolean;
+  stopMusicBeat: () => void;
 }
 
 /**
@@ -114,6 +117,13 @@ export function registerMusicIpcHandlers(options: RegisterMusicIpcHandlersOption
       console.error('[LyricsKaraoke] persist error:', err);
       return false;
     }
+  });
+
+  ipcMain.handle('music:marquee-beat:start', () => options.startMusicBeat());
+  ipcMain.handle('music:marquee-beat:get', () => options.getMusicBeat());
+  ipcMain.handle('music:marquee-beat:stop', () => {
+    options.stopMusicBeat();
+    return true;
   });
 
   ipcMain.handle('music:lyrics-clock:get', () => {

--- a/src/main/ipc/media/test/mediaHandlers.test.ts
+++ b/src/main/ipc/media/test/mediaHandlers.test.ts
@@ -257,6 +257,9 @@ describe('media ipc handlers', () => {
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{ sourceAppId: 'spotify', isPlaying: true, hasTitle: true, thumbnail: null }])
         .mockRejectedValueOnce(new Error('boom')),
+      getMusicBeat: vi.fn().mockReturnValue({}),
+      startMusicBeat: vi.fn().mockReturnValue(true),
+      stopMusicBeat: vi.fn(),
     });
 
     const event = { sender: { id: 42 } };

--- a/src/main/ipc/media/test/music.test.ts
+++ b/src/main/ipc/media/test/music.test.ts
@@ -88,6 +88,9 @@ describe('registerMusicIpcHandlers', () => {
       setSmtcUnsubscribeMs: vi.fn(),
       sanitizeSmtcUnsubscribeMs: vi.fn((v: unknown) => Number(v) || 3000),
       detectAllSources: vi.fn().mockResolvedValue([]),
+      getMusicBeat: vi.fn().mockReturnValue({}),
+      startMusicBeat: vi.fn().mockReturnValue(true),
+      stopMusicBeat: vi.fn(),
     };
     registerMusicIpcHandlers({ ...defaults, ...overrides });
   }
@@ -451,9 +454,9 @@ describe('registerMusicIpcHandlers', () => {
   // ipcMain.handle registration
   // ---------------------------------------------------------------
   describe('channel registration', () => {
-    it('registers exactly 15 IPC channels', () => {
+    it('registers exactly 22 IPC channels', () => {
       register();
-      expect(handleMock).toHaveBeenCalledTimes(19);
+      expect(handleMock).toHaveBeenCalledTimes(22);
     });
 
     it('registers all expected channels', () => {
@@ -464,6 +467,9 @@ describe('registerMusicIpcHandlers', () => {
         'music:lyrics-source:set',
         'music:lyrics-karaoke:get',
         'music:lyrics-karaoke:set',
+        'music:marquee-beat:start',
+        'music:marquee-beat:get',
+        'music:marquee-beat:stop',
         'music:lyrics-clock:get',
         'music:lyrics-clock:set',
         'music:lyrics-calibrate-enabled:get',

--- a/src/main/music/musicBeatSource.ts
+++ b/src/main/music/musicBeatSource.ts
@@ -1,0 +1,95 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file musicBeatSource.ts
+ * @description 将 SMTC 播放源标识解析为对应的活动音频进程。
+ * @author 鸡哥
+ */
+
+export interface MusicAudioProcess {
+  processId: number;
+  processName: string | null;
+  displayName: string | null;
+}
+
+const MUSIC_SOURCE_ALIAS_GROUPS: readonly (readonly string[])[] = [
+  ['spotify', 'spotifymusic'],
+  ['汽水音乐', 'sodamusic', 'qishui', 'qishuimusic', 'douyinmusic'],
+  ['qqmusic', 'tencentqqmusic', 'QQMusic'],
+  ['cloudmusic', 'neteasecloudmusic', 'orpheus'],
+  ['kugou', 'kugoumusic'],
+  ['kuwo', 'kuwomusic'],
+  ['applemusic', 'applemusicwin'],
+  ['zunemusic', 'groovemusic', 'musicui'],
+  ['chrome', 'googlechrome'],
+  ['msedge', 'microsoftedge'],
+  ['firefox', 'mozillafirefox'],
+];
+
+/**
+ * 标准化播放器标识。
+ * @param value - SMTC 源、进程名或音频会话显示名。
+ * @returns 仅包含小写字母和数字的标识。
+ */
+export function normalizeMusicSourceId(value: string): string {
+  return value.toLowerCase().replace(/\.exe\b/g, '').replace(/[^a-z0-9]/g, '');
+}
+
+function matchesAliasGroup(sourceId: string, candidateId: string): boolean {
+  return MUSIC_SOURCE_ALIAS_GROUPS.some((aliases) => {
+    const sourceMatched = aliases.some((alias) => sourceId.includes(alias));
+    const candidateMatched = aliases.some((alias) => candidateId.includes(alias));
+    return sourceMatched && candidateMatched;
+  });
+}
+
+/**
+ * 解析与 SMTC 当前源对应的活动音频进程。
+ * @description 名称无法关联时，仅在候选唯一的情况下回退，避免监听到其他同时发声的程序。
+ * @param sourceAppId - SMTC 当前锁定的 Source App ID 或 AUMID。
+ * @param processes - 当前活动音频进程列表。
+ * @returns 匹配到的音频进程；无法安全确定时返回 undefined。
+ */
+export function resolveMusicAudioProcess(
+  sourceAppId: string,
+  processes: readonly MusicAudioProcess[],
+): MusicAudioProcess | undefined {
+  const normalizedSourceId = normalizeMusicSourceId(sourceAppId);
+  const directMatch = processes.find((process) => {
+    const processName = normalizeMusicSourceId(process.processName ?? '');
+    const displayName = normalizeMusicSourceId(process.displayName ?? '');
+    return Boolean(
+      (processName && (normalizedSourceId.includes(processName) || processName.includes(normalizedSourceId)))
+      || (displayName && (normalizedSourceId.includes(displayName) || displayName.includes(normalizedSourceId))),
+    );
+  });
+  if (directMatch) return directMatch;
+
+  const aliasMatch = processes.find((process) => {
+    const processName = normalizeMusicSourceId(process.processName ?? '');
+    const displayName = normalizeMusicSourceId(process.displayName ?? '');
+    return matchesAliasGroup(normalizedSourceId, processName)
+      || matchesAliasGroup(normalizedSourceId, displayName);
+  });
+  if (aliasMatch) return aliasMatch;
+
+  return processes.length === 1 ? processes[0] : undefined;
+}

--- a/src/main/music/test/musicBeatSource.test.ts
+++ b/src/main/music/test/musicBeatSource.test.ts
@@ -1,0 +1,72 @@
+/*
+ * eIsland - A sleek, Apple Dynamic Island inspired floating widget for Windows, built with Electron.
+ * https://github.com/JNTMTMTM/eIsland
+ *
+ * Copyright (C) 2026 JNTMTMTM
+ * Copyright (C) 2026 pyisland.com
+ *
+ * Original author: JNTMTMTM[](https://github.com/JNTMTMTM)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/**
+ * @file musicBeatSource.test.ts
+ * @description SMTC 播放源与活动音频进程匹配测试。
+ * @author 鸡哥
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeMusicSourceId, resolveMusicAudioProcess } from '../musicBeatSource';
+
+const process = (processId: number, processName: string, displayName = '') => ({
+  processId,
+  processName,
+  displayName,
+});
+
+describe('musicBeatSource', () => {
+  it('normalizes executable and AUMID separators', () => {
+    expect(normalizeMusicSourceId('Spotify.exe')).toBe('spotify');
+    expect(normalizeMusicSourceId('SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify')).toBe('spotifyabspotifymusiczpdnekdrzrea0spotify');
+  });
+
+  it('matches a process directly from the SMTC source', () => {
+    const target = resolveMusicAudioProcess('SodaMusic.exe', [
+      process(10, 'chrome'),
+      process(20, 'SodaMusic'),
+    ]);
+
+    expect(target?.processId).toBe(20);
+  });
+
+  it('matches known aliases when SMTC and process names differ', () => {
+    const spotify = resolveMusicAudioProcess('SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify', [
+      process(10, 'chrome'),
+      process(20, 'Spotify'),
+    ]);
+    const netease = resolveMusicAudioProcess('NetEase.CloudMusic', [
+      process(30, 'orpheus'),
+      process(40, 'msedge'),
+    ]);
+
+    expect(spotify?.processId).toBe(20);
+    expect(netease?.processId).toBe(30);
+  });
+
+  it('falls back only when one active audio process exists', () => {
+    expect(resolveMusicAudioProcess('Unknown.Player', [process(10, 'actual-player')])?.processId).toBe(10);
+    expect(resolveMusicAudioProcess('Unknown.Player', [
+      process(10, 'actual-player'),
+      process(20, 'other-audio'),
+    ])).toBeUndefined();
+  });
+});

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -34,6 +34,7 @@ import type {
   SaveTextFilePayload,
   SaveTextFileResult,
   ComputeFileHashResult,
+  MusicMarqueeBeatResult,
   ExecuteAgentLocalToolRequest,
   ExecuteAgentLocalToolResult,
   OllamaChatRequest,
@@ -234,12 +235,7 @@ declare global {
       musicLyricsKaraokeGet: () => Promise<boolean>;
       musicLyricsKaraokeSet: (enabled: boolean) => Promise<boolean>;
       musicMarqueeBeatStart: () => Promise<boolean>;
-      musicMarqueeBeatGet: () => Promise<{
-        error: string | null;
-        frequency: { dominantHz: number; spectrum: number[] };
-        amplitude: { rms: number; peak: number };
-        beat: { isBeat: boolean; bpm: number; intensity: number };
-      }>;
+      musicMarqueeBeatGet: () => Promise<MusicMarqueeBeatResult | null>;
       musicMarqueeBeatStop: () => Promise<boolean>;
       musicLyricsClockGet: () => Promise<boolean>;
       musicLyricsClockSet: (enabled: boolean) => Promise<boolean>;

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -233,6 +233,14 @@ declare global {
       musicLyricsTranslationEnabledSet: (enabled: boolean) => Promise<boolean>;
       musicLyricsKaraokeGet: () => Promise<boolean>;
       musicLyricsKaraokeSet: (enabled: boolean) => Promise<boolean>;
+      musicMarqueeBeatStart: () => Promise<boolean>;
+      musicMarqueeBeatGet: () => Promise<{
+        error: string | null;
+        frequency: { dominantHz: number; spectrum: number[] };
+        amplitude: { rms: number; peak: number };
+        beat: { isBeat: boolean; bpm: number; intensity: number };
+      }>;
+      musicMarqueeBeatStop: () => Promise<boolean>;
       musicLyricsClockGet: () => Promise<boolean>;
       musicLyricsClockSet: (enabled: boolean) => Promise<boolean>;
       musicLyricsCalibrateEnabledGet: () => Promise<boolean>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -76,6 +76,7 @@ import type {
   ClaudeCodeHookMutationResult,
   CodexStatusSnapshot,
   CodexMonitorMutationResult,
+  MusicMarqueeBeatResult,
 } from './types';
 
 /** 自定义 API，供渲染进程调用 */
@@ -1093,7 +1094,7 @@ const api = {
     return ipcRenderer.invoke('music:marquee-beat:start');
   },
   /** 获取跑马灯节拍分析结果 */
-  musicMarqueeBeatGet: (): Promise<unknown> => {
+  musicMarqueeBeatGet: (): Promise<MusicMarqueeBeatResult | null> => {
     return ipcRenderer.invoke('music:marquee-beat:get');
   },
   /** 停止跑马灯节拍分析 */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1088,6 +1088,18 @@ const api = {
   musicLyricsKaraokeSet: (enabled: boolean): Promise<boolean> => {
     return ipcRenderer.invoke('music:lyrics-karaoke:set', enabled);
   },
+  /** 启动跑马灯节拍分析 */
+  musicMarqueeBeatStart: (): Promise<boolean> => {
+    return ipcRenderer.invoke('music:marquee-beat:start');
+  },
+  /** 获取跑马灯节拍分析结果 */
+  musicMarqueeBeatGet: (): Promise<unknown> => {
+    return ipcRenderer.invoke('music:marquee-beat:get');
+  },
+  /** 停止跑马灯节拍分析 */
+  musicMarqueeBeatStop: (): Promise<boolean> => {
+    return ipcRenderer.invoke('music:marquee-beat:stop');
+  },
   /**
    * 获取歌词界面时钟开关
    * @returns 是否显示时钟

--- a/src/preload/types/media.ts
+++ b/src/preload/types/media.ts
@@ -77,3 +77,21 @@ export interface SourceSwitchRequestData {
   title: string;
   artist: string;
 }
+
+/** 频率峰值 */
+export interface MarqueeFrequencyPeak {
+  hz: number;
+  magnitude: number;
+}
+
+/** 跑马灯节拍分析结果（对应 volume-analyzer 插件的 AudioAnalysisResult） */
+export interface MusicMarqueeBeatResult {
+  error: string | null;
+  frequency: {
+    spectrum: number[];
+    dominantHz: number;
+    topFrequencies: MarqueeFrequencyPeak[];
+  };
+  amplitude: { rms: number; peak: number };
+  beat: { isBeat: boolean; bpm: number; intensity: number };
+}

--- a/src/renderer/components/hooks/useDynamicIslandCoordinator.ts
+++ b/src/renderer/components/hooks/useDynamicIslandCoordinator.ts
@@ -155,6 +155,8 @@ export function useDynamicIslandCoordinator(options: UseDynamicIslandCoordinator
     morphing,
     fromState,
     showGlow,
+    marqueeRhythmEnabled,
+    marqueeBeatPulse,
     handleIslandClick,
   } = useDynamicIslandShell({
     state,
@@ -305,6 +307,8 @@ export function useDynamicIslandCoordinator(options: UseDynamicIslandCoordinator
     morphing,
     fromState,
     showGlow,
+    marqueeRhythmEnabled,
+    marqueeBeatPulse,
     springAnimation,
     animationSpeed,
     shapeMode,

--- a/src/renderer/components/hooks/useDynamicIslandCoordinator.ts
+++ b/src/renderer/components/hooks/useDynamicIslandCoordinator.ts
@@ -156,6 +156,8 @@ export function useDynamicIslandCoordinator(options: UseDynamicIslandCoordinator
     fromState,
     showGlow,
     marqueeRhythmEnabled,
+    marqueeAmplitudeEnabled,
+    marqueeAmplitudeLevel,
     marqueeBeatPulse,
     handleIslandClick,
   } = useDynamicIslandShell({
@@ -308,6 +310,8 @@ export function useDynamicIslandCoordinator(options: UseDynamicIslandCoordinator
     fromState,
     showGlow,
     marqueeRhythmEnabled,
+    marqueeAmplitudeEnabled,
+    marqueeAmplitudeLevel,
     marqueeBeatPulse,
     springAnimation,
     animationSpeed,

--- a/src/renderer/components/hooks/useDynamicIslandShell.ts
+++ b/src/renderer/components/hooks/useDynamicIslandShell.ts
@@ -124,6 +124,8 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
     let beatClockTimer: number | undefined;
     let lastNativeBeatAt = 0;
     let smoothedAmplitude = 0;
+    let amplitudeBaseline = 0;
+    let amplitudeCeiling = 0.18;
     const bpmSamples: number[] = [];
 
     const triggerPulse = (): void => {
@@ -150,9 +152,16 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
       window.api.musicMarqueeBeatGet().then((result) => {
         if (cancelled || !result) return;
         if (marqueeMode === 'amplitude') {
-          const sampleStrength = Math.min(1, Math.max(result.amplitude.rms * 2.4, result.amplitude.peak * 0.7));
-          const gatedStrength = sampleStrength < 0.05 ? 0 : sampleStrength;
-          smoothedAmplitude = smoothedAmplitude * 0.68 + gatedStrength * 0.32;
+          const sampleStrength = result.amplitude.rms * 0.9 + result.amplitude.peak * 0.1;
+          amplitudeBaseline = amplitudeBaseline === 0
+            ? sampleStrength
+            : amplitudeBaseline * 0.96 + sampleStrength * 0.04;
+          amplitudeCeiling = Math.max(sampleStrength, amplitudeCeiling * 0.99);
+          const dynamicRange = Math.max(0.06, amplitudeCeiling - amplitudeBaseline);
+          const normalizedStrength = Math.min(1, Math.max(0, (sampleStrength - amplitudeBaseline) / dynamicRange));
+          const targetAmplitude = normalizedStrength ** 1.4;
+          const smoothingFactor = targetAmplitude > smoothedAmplitude ? 0.4 : 0.16;
+          smoothedAmplitude += (targetAmplitude - smoothedAmplitude) * smoothingFactor;
           setMarqueeAmplitudeLevel(smoothedAmplitude);
           return;
         }

--- a/src/renderer/components/hooks/useDynamicIslandShell.ts
+++ b/src/renderer/components/hooks/useDynamicIslandShell.ts
@@ -27,9 +27,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useIslandStore from '../../store/isLandStore';
 import type { IslandState } from '../../store/types';
-
-const MUSIC_OUTER_GLOW_EFFECT_STORE_KEY = 'music-outer-glow-effect-enabled';
-const MUSIC_MARQUEE_MODE_STORE_KEY = 'music-marquee-mode';
+import {
+  MUSIC_OUTER_GLOW_EFFECT_STORE_KEY,
+  MUSIC_MARQUEE_MODE_STORE_KEY,
+  isMusicMarqueeMode,
+} from '../states/lyrics/config/lyricsConstants';
+import type { MusicMarqueeMode } from '../states/lyrics/config/lyricsConstants';
 
 export type { IslandState };
 
@@ -89,19 +92,21 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
   const [morphing, setMorphing] = useState(false);
   const [fromState, setFromState] = useState('');
   const [glowEffectEnabled, setGlowEffectEnabled] = useState<boolean>(true);
-  const [marqueeMode, setMarqueeMode] = useState<'normal' | 'rhythm' | 'amplitude'>('normal');
+  const [marqueeMode, setMarqueeMode] = useState<MusicMarqueeMode>('normal');
   const [marqueeBeatPulse, setMarqueeBeatPulse] = useState(false);
   const [marqueeAmplitudeLevel, setMarqueeAmplitudeLevel] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
-      if (!cancelled && (value === 'normal' || value === 'rhythm' || value === 'amplitude')) setMarqueeMode(value);
-    }).catch(() => {});
+      if (!cancelled && isMusicMarqueeMode(value)) setMarqueeMode(value);
+    }).catch((err) => {
+      console.warn('[MarqueeBeat] failed to read marquee mode:', err);
+    });
 
     const handler = (event: Event): void => {
       const value = (event as CustomEvent).detail;
-      if (value === 'normal' || value === 'rhythm' || value === 'amplitude') setMarqueeMode(value);
+      if (isMusicMarqueeMode(value)) setMarqueeMode(value);
     };
     window.addEventListener('music-marquee-mode-changed', handler);
     return () => {
@@ -113,7 +118,9 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
   useEffect(() => {
     const usesAnalyzer = marqueeMode === 'rhythm' || marqueeMode === 'amplitude';
     if (!usesAnalyzer || !isMusicPlaying || !isPlaying || !glowEffectEnabled) {
-      window.api.musicMarqueeBeatStop().catch(() => {});
+      window.api.musicMarqueeBeatStop().catch((err) => {
+        console.warn('[MarqueeBeat] stop failed:', err);
+      });
       setMarqueeBeatPulse(false);
       setMarqueeAmplitudeLevel(0);
       return;
@@ -147,7 +154,9 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
       beatClockTimer = window.setTimeout(tick, periodMs);
     };
 
-    window.api.musicMarqueeBeatStart().catch(() => {});
+    window.api.musicMarqueeBeatStart().catch((err) => {
+      console.warn('[MarqueeBeat] start failed:', err);
+    });
     const pollTimer = window.setInterval(() => {
       window.api.musicMarqueeBeatGet().then((result) => {
         if (cancelled || !result) return;
@@ -183,7 +192,9 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
         const periodMs = subdivision === 8 ? 30_000 / baseBpm : 60_000 / baseBpm;
         triggerPulse();
         synchronizeBeatClock(periodMs);
-      }).catch(() => {});
+      }).catch((err) => {
+        if (!cancelled) console.warn('[MarqueeBeat] poll failed:', err);
+      });
     }, marqueeMode === 'amplitude' ? 50 : 80);
 
     return () => {
@@ -192,7 +203,9 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
       if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
       if (beatClockTimer !== undefined) window.clearTimeout(beatClockTimer);
       setMarqueeAmplitudeLevel(0);
-      window.api.musicMarqueeBeatStop().catch(() => {});
+      window.api.musicMarqueeBeatStop().catch((err) => {
+        console.warn('[MarqueeBeat] stop failed:', err);
+      });
     };
   }, [glowEffectEnabled, isMusicPlaying, isPlaying, marqueeMode]);
 

--- a/src/renderer/components/hooks/useDynamicIslandShell.ts
+++ b/src/renderer/components/hooks/useDynamicIslandShell.ts
@@ -116,29 +116,49 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
 
     let cancelled = false;
     let pulseTimer: number | undefined;
-    let averageRms = 0;
-    let lastPulseAt = 0;
+    let beatClockTimer: number | undefined;
+    let lastNativeBeatAt = 0;
+    const bpmSamples: number[] = [];
+
+    const triggerPulse = (): void => {
+      setMarqueeBeatPulse(false);
+      window.requestAnimationFrame(() => {
+        if (!cancelled) setMarqueeBeatPulse(true);
+      });
+      if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
+      pulseTimer = window.setTimeout(() => setMarqueeBeatPulse(false), 280);
+    };
+
+    const synchronizeBeatClock = (periodMs: number): void => {
+      if (beatClockTimer !== undefined) window.clearTimeout(beatClockTimer);
+      const tick = (): void => {
+        if (cancelled) return;
+        triggerPulse();
+        beatClockTimer = window.setTimeout(tick, periodMs);
+      };
+      beatClockTimer = window.setTimeout(tick, periodMs);
+    };
+
     window.api.musicMarqueeBeatStart().catch(() => {});
     const pollTimer = window.setInterval(() => {
       window.api.musicMarqueeBeatGet().then((result) => {
-        if (cancelled) return;
-        const rms = result?.amplitude.rms ?? 0;
-        const peak = result?.amplitude.peak ?? 0;
-        const now = performance.now();
-        const amplitudeBeat = averageRms > 0
-          && rms > Math.max(0.08, averageRms * 1.35)
-          && peak > 0.25
-          && now - lastPulseAt >= 180;
-        averageRms = averageRms === 0 ? rms : averageRms * 0.82 + rms * 0.18;
-        if (result?.beat.isBeat !== true && !amplitudeBeat) return;
+        if (cancelled || beatClockTimer !== undefined || result?.beat.isBeat !== true) return;
+        const bpm = result.beat.bpm;
+        if (!Number.isFinite(bpm) || bpm < 30 || bpm > 300) return;
 
-        lastPulseAt = now;
-        setMarqueeBeatPulse(false);
-        window.requestAnimationFrame(() => {
-          if (!cancelled) setMarqueeBeatPulse(true);
-        });
-        if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
-        pulseTimer = window.setTimeout(() => setMarqueeBeatPulse(false), 180);
+        const now = performance.now();
+        if (now - lastNativeBeatAt < 150) return;
+        lastNativeBeatAt = now;
+        bpmSamples.push(bpm);
+        if (bpmSamples.length < 4) return;
+
+        const sortedBpms = [...bpmSamples].sort((left, right) => left - right);
+        const detectedBpm = sortedBpms[Math.floor(sortedBpms.length / 2)];
+        const subdivision = detectedBpm >= 160 ? 8 : 4;
+        const baseBpm = subdivision === 8 ? detectedBpm / 2 : detectedBpm;
+        const periodMs = subdivision === 8 ? 30_000 / baseBpm : 60_000 / baseBpm;
+        triggerPulse();
+        synchronizeBeatClock(periodMs);
       }).catch(() => {});
     }, 80);
 
@@ -146,6 +166,7 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
       cancelled = true;
       window.clearInterval(pollTimer);
       if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
+      if (beatClockTimer !== undefined) window.clearTimeout(beatClockTimer);
       window.api.musicMarqueeBeatStop().catch(() => {});
     };
   }, [glowEffectEnabled, isMusicPlaying, isPlaying, marqueeMode]);

--- a/src/renderer/components/hooks/useDynamicIslandShell.ts
+++ b/src/renderer/components/hooks/useDynamicIslandShell.ts
@@ -57,6 +57,8 @@ interface DynamicIslandShellState {
   fromState: string;
   showGlow: string | null;
   marqueeRhythmEnabled: boolean;
+  marqueeAmplitudeEnabled: boolean;
+  marqueeAmplitudeLevel: number;
   marqueeBeatPulse: boolean;
   handleIslandClick: () => void;
 }
@@ -87,18 +89,19 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
   const [morphing, setMorphing] = useState(false);
   const [fromState, setFromState] = useState('');
   const [glowEffectEnabled, setGlowEffectEnabled] = useState<boolean>(true);
-  const [marqueeMode, setMarqueeMode] = useState<'normal' | 'rhythm'>('normal');
+  const [marqueeMode, setMarqueeMode] = useState<'normal' | 'rhythm' | 'amplitude'>('normal');
   const [marqueeBeatPulse, setMarqueeBeatPulse] = useState(false);
+  const [marqueeAmplitudeLevel, setMarqueeAmplitudeLevel] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
-      if (!cancelled && (value === 'normal' || value === 'rhythm')) setMarqueeMode(value);
+      if (!cancelled && (value === 'normal' || value === 'rhythm' || value === 'amplitude')) setMarqueeMode(value);
     }).catch(() => {});
 
     const handler = (event: Event): void => {
       const value = (event as CustomEvent).detail;
-      if (value === 'normal' || value === 'rhythm') setMarqueeMode(value);
+      if (value === 'normal' || value === 'rhythm' || value === 'amplitude') setMarqueeMode(value);
     };
     window.addEventListener('music-marquee-mode-changed', handler);
     return () => {
@@ -108,9 +111,11 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
   }, []);
 
   useEffect(() => {
-    if (marqueeMode !== 'rhythm' || !isMusicPlaying || !isPlaying || !glowEffectEnabled) {
+    const usesAnalyzer = marqueeMode === 'rhythm' || marqueeMode === 'amplitude';
+    if (!usesAnalyzer || !isMusicPlaying || !isPlaying || !glowEffectEnabled) {
       window.api.musicMarqueeBeatStop().catch(() => {});
       setMarqueeBeatPulse(false);
+      setMarqueeAmplitudeLevel(0);
       return;
     }
 
@@ -118,6 +123,7 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
     let pulseTimer: number | undefined;
     let beatClockTimer: number | undefined;
     let lastNativeBeatAt = 0;
+    let smoothedAmplitude = 0;
     const bpmSamples: number[] = [];
 
     const triggerPulse = (): void => {
@@ -142,7 +148,16 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
     window.api.musicMarqueeBeatStart().catch(() => {});
     const pollTimer = window.setInterval(() => {
       window.api.musicMarqueeBeatGet().then((result) => {
-        if (cancelled || beatClockTimer !== undefined || result?.beat.isBeat !== true) return;
+        if (cancelled || !result) return;
+        if (marqueeMode === 'amplitude') {
+          const sampleStrength = Math.min(1, Math.max(result.amplitude.rms * 2.4, result.amplitude.peak * 0.7));
+          const gatedStrength = sampleStrength < 0.05 ? 0 : sampleStrength;
+          smoothedAmplitude = smoothedAmplitude * 0.68 + gatedStrength * 0.32;
+          setMarqueeAmplitudeLevel(smoothedAmplitude);
+          return;
+        }
+
+        if (beatClockTimer !== undefined || result.beat.isBeat !== true) return;
         const bpm = result.beat.bpm;
         if (!Number.isFinite(bpm) || bpm < 30 || bpm > 300) return;
 
@@ -160,13 +175,14 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
         triggerPulse();
         synchronizeBeatClock(periodMs);
       }).catch(() => {});
-    }, 80);
+    }, marqueeMode === 'amplitude' ? 50 : 80);
 
     return () => {
       cancelled = true;
       window.clearInterval(pollTimer);
       if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
       if (beatClockTimer !== undefined) window.clearTimeout(beatClockTimer);
+      setMarqueeAmplitudeLevel(0);
       window.api.musicMarqueeBeatStop().catch(() => {});
     };
   }, [glowEffectEnabled, isMusicPlaying, isPlaying, marqueeMode]);
@@ -235,6 +251,8 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
     fromState,
     showGlow: glowEffectEnabled && isMusicPlaying && coverImage ? (isPlaying ? 'playing' : 'paused') : null,
     marqueeRhythmEnabled: marqueeMode === 'rhythm',
+    marqueeAmplitudeEnabled: marqueeMode === 'amplitude',
+    marqueeAmplitudeLevel,
     marqueeBeatPulse,
     handleIslandClick,
   };

--- a/src/renderer/components/hooks/useDynamicIslandShell.ts
+++ b/src/renderer/components/hooks/useDynamicIslandShell.ts
@@ -29,6 +29,7 @@ import useIslandStore from '../../store/isLandStore';
 import type { IslandState } from '../../store/types';
 
 const MUSIC_OUTER_GLOW_EFFECT_STORE_KEY = 'music-outer-glow-effect-enabled';
+const MUSIC_MARQUEE_MODE_STORE_KEY = 'music-marquee-mode';
 
 export type { IslandState };
 
@@ -55,6 +56,8 @@ interface DynamicIslandShellState {
   morphing: boolean;
   fromState: string;
   showGlow: string | null;
+  marqueeRhythmEnabled: boolean;
+  marqueeBeatPulse: boolean;
   handleIslandClick: () => void;
 }
 
@@ -84,6 +87,68 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
   const [morphing, setMorphing] = useState(false);
   const [fromState, setFromState] = useState('');
   const [glowEffectEnabled, setGlowEffectEnabled] = useState<boolean>(true);
+  const [marqueeMode, setMarqueeMode] = useState<'normal' | 'rhythm'>('normal');
+  const [marqueeBeatPulse, setMarqueeBeatPulse] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
+      if (!cancelled && (value === 'normal' || value === 'rhythm')) setMarqueeMode(value);
+    }).catch(() => {});
+
+    const handler = (event: Event): void => {
+      const value = (event as CustomEvent).detail;
+      if (value === 'normal' || value === 'rhythm') setMarqueeMode(value);
+    };
+    window.addEventListener('music-marquee-mode-changed', handler);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('music-marquee-mode-changed', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (marqueeMode !== 'rhythm' || !isMusicPlaying || !isPlaying || !glowEffectEnabled) {
+      window.api.musicMarqueeBeatStop().catch(() => {});
+      setMarqueeBeatPulse(false);
+      return;
+    }
+
+    let cancelled = false;
+    let pulseTimer: number | undefined;
+    let averageRms = 0;
+    let lastPulseAt = 0;
+    window.api.musicMarqueeBeatStart().catch(() => {});
+    const pollTimer = window.setInterval(() => {
+      window.api.musicMarqueeBeatGet().then((result) => {
+        if (cancelled) return;
+        const rms = result?.amplitude.rms ?? 0;
+        const peak = result?.amplitude.peak ?? 0;
+        const now = performance.now();
+        const amplitudeBeat = averageRms > 0
+          && rms > Math.max(0.08, averageRms * 1.35)
+          && peak > 0.25
+          && now - lastPulseAt >= 180;
+        averageRms = averageRms === 0 ? rms : averageRms * 0.82 + rms * 0.18;
+        if (result?.beat.isBeat !== true && !amplitudeBeat) return;
+
+        lastPulseAt = now;
+        setMarqueeBeatPulse(false);
+        window.requestAnimationFrame(() => {
+          if (!cancelled) setMarqueeBeatPulse(true);
+        });
+        if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
+        pulseTimer = window.setTimeout(() => setMarqueeBeatPulse(false), 180);
+      }).catch(() => {});
+    }, 80);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(pollTimer);
+      if (pulseTimer !== undefined) window.clearTimeout(pulseTimer);
+      window.api.musicMarqueeBeatStop().catch(() => {});
+    };
+  }, [glowEffectEnabled, isMusicPlaying, isPlaying, marqueeMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -148,6 +213,8 @@ export function useDynamicIslandShell(options: UseDynamicIslandShellOptions): Dy
     morphing,
     fromState,
     showGlow: glowEffectEnabled && isMusicPlaying && coverImage ? (isPlaying ? 'playing' : 'paused') : null,
+    marqueeRhythmEnabled: marqueeMode === 'rhythm',
+    marqueeBeatPulse,
     handleIslandClick,
   };
 }

--- a/src/renderer/components/hooks/useIslandShellPresentation.ts
+++ b/src/renderer/components/hooks/useIslandShellPresentation.ts
@@ -33,6 +33,8 @@ interface UseIslandShellPresentationOptions {
   morphing: boolean;
   fromState: string;
   showGlow: string | null;
+  marqueeRhythmEnabled: boolean;
+  marqueeBeatPulse: boolean;
   springAnimation: boolean;
   animationSpeed: string;
   shapeMode: IslandShapeMode;
@@ -55,6 +57,8 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
     morphing,
     fromState,
     showGlow,
+    marqueeRhythmEnabled,
+    marqueeBeatPulse,
     springAnimation,
     animationSpeed,
     shapeMode,
@@ -62,8 +66,8 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
   } = options;
 
   const shellClassName = useMemo(() => {
-    return `island-shell shape-${shapeMode} ${getStateClassName(state as Parameters<typeof getStateClassName>[0])}${morphing ? ' morphing' : ''}${fromState ? ` from-${fromState}` : ''}${showGlow ? ' music-glow' : ''}${showGlow === 'paused' ? ' music-paused' : ''}${springAnimation ? ' spring-animation' : ''} speed-${animationSpeed}`;
-  }, [state, morphing, fromState, showGlow, springAnimation, animationSpeed, shapeMode]);
+    return `island-shell shape-${shapeMode} ${getStateClassName(state as Parameters<typeof getStateClassName>[0])}${morphing ? ' morphing' : ''}${fromState ? ` from-${fromState}` : ''}${showGlow ? ' music-glow' : ''}${showGlow === 'paused' ? ' music-paused' : ''}${marqueeRhythmEnabled ? ' music-glow-rhythm' : ''}${marqueeBeatPulse ? ' music-glow-beat' : ''}${springAnimation ? ' spring-animation' : ''} speed-${animationSpeed}`;
+  }, [state, morphing, fromState, showGlow, marqueeRhythmEnabled, marqueeBeatPulse, springAnimation, animationSpeed, shapeMode]);
 
   const shellStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (!showGlow) return undefined;

--- a/src/renderer/components/hooks/useIslandShellPresentation.ts
+++ b/src/renderer/components/hooks/useIslandShellPresentation.ts
@@ -80,7 +80,7 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
       '--glow-r': r,
       '--glow-g': g,
       '--glow-b': b,
-      '--music-glow-inset': `${2 + marqueeAmplitudeLevel * 8}px`,
+      '--music-glow-inset': `${2 + marqueeAmplitudeLevel * 5.5}px`,
       '--music-glow-opacity': 0.62 + marqueeAmplitudeLevel * 0.36,
     } as React.CSSProperties;
   }, [showGlow, dominantColor, marqueeAmplitudeLevel]);

--- a/src/renderer/components/hooks/useIslandShellPresentation.ts
+++ b/src/renderer/components/hooks/useIslandShellPresentation.ts
@@ -81,7 +81,7 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
       '--glow-g': g,
       '--glow-b': b,
       '--music-glow-inset': `${2 + marqueeAmplitudeLevel * 8}px`,
-      '--music-glow-opacity': 0.45 + marqueeAmplitudeLevel * 0.5,
+      '--music-glow-opacity': 0.62 + marqueeAmplitudeLevel * 0.36,
     } as React.CSSProperties;
   }, [showGlow, dominantColor, marqueeAmplitudeLevel]);
 

--- a/src/renderer/components/hooks/useIslandShellPresentation.ts
+++ b/src/renderer/components/hooks/useIslandShellPresentation.ts
@@ -34,6 +34,8 @@ interface UseIslandShellPresentationOptions {
   fromState: string;
   showGlow: string | null;
   marqueeRhythmEnabled: boolean;
+  marqueeAmplitudeEnabled: boolean;
+  marqueeAmplitudeLevel: number;
   marqueeBeatPulse: boolean;
   springAnimation: boolean;
   animationSpeed: string;
@@ -58,6 +60,8 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
     fromState,
     showGlow,
     marqueeRhythmEnabled,
+    marqueeAmplitudeEnabled,
+    marqueeAmplitudeLevel,
     marqueeBeatPulse,
     springAnimation,
     animationSpeed,
@@ -66,8 +70,8 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
   } = options;
 
   const shellClassName = useMemo(() => {
-    return `island-shell shape-${shapeMode} ${getStateClassName(state as Parameters<typeof getStateClassName>[0])}${morphing ? ' morphing' : ''}${fromState ? ` from-${fromState}` : ''}${showGlow ? ' music-glow' : ''}${showGlow === 'paused' ? ' music-paused' : ''}${marqueeRhythmEnabled ? ' music-glow-rhythm' : ''}${marqueeBeatPulse ? ' music-glow-beat' : ''}${springAnimation ? ' spring-animation' : ''} speed-${animationSpeed}`;
-  }, [state, morphing, fromState, showGlow, marqueeRhythmEnabled, marqueeBeatPulse, springAnimation, animationSpeed, shapeMode]);
+    return `island-shell shape-${shapeMode} ${getStateClassName(state as Parameters<typeof getStateClassName>[0])}${morphing ? ' morphing' : ''}${fromState ? ` from-${fromState}` : ''}${showGlow ? ' music-glow' : ''}${showGlow === 'paused' ? ' music-paused' : ''}${marqueeRhythmEnabled ? ' music-glow-rhythm' : ''}${marqueeAmplitudeEnabled ? ' music-glow-amplitude' : ''}${marqueeBeatPulse ? ' music-glow-beat' : ''}${springAnimation ? ' spring-animation' : ''} speed-${animationSpeed}`;
+  }, [state, morphing, fromState, showGlow, marqueeRhythmEnabled, marqueeAmplitudeEnabled, marqueeBeatPulse, springAnimation, animationSpeed, shapeMode]);
 
   const shellStyle = useMemo<React.CSSProperties | undefined>(() => {
     if (!showGlow) return undefined;
@@ -76,8 +80,10 @@ export function useIslandShellPresentation(options: UseIslandShellPresentationOp
       '--glow-r': r,
       '--glow-g': g,
       '--glow-b': b,
+      '--music-glow-inset': `${2 + marqueeAmplitudeLevel * 8}px`,
+      '--music-glow-opacity': 0.45 + marqueeAmplitudeLevel * 0.5,
     } as React.CSSProperties;
-  }, [showGlow, dominantColor]);
+  }, [showGlow, dominantColor, marqueeAmplitudeLevel]);
 
   return {
     shellClassName,

--- a/src/renderer/components/states/lyrics/config/lyricsConstants.ts
+++ b/src/renderer/components/states/lyrics/config/lyricsConstants.ts
@@ -20,9 +20,20 @@
 
 /**
  * @file lyricsConstants.ts
- * @description 歌词组件配置常量
+ * @description 歌词与音乐光效组件共享常量
  * @author 鸡哥
  */
 
 /** 音乐外发光效果的持久化存储键 */
 export const MUSIC_OUTER_GLOW_EFFECT_STORE_KEY = 'music-outer-glow-effect-enabled';
+
+/** 跑马灯模式持久化存储键 */
+export const MUSIC_MARQUEE_MODE_STORE_KEY = 'music-marquee-mode';
+
+/** 跑马灯工作模式 */
+export type MusicMarqueeMode = 'normal' | 'rhythm' | 'amplitude';
+
+/** 判断值是否为合法的跑马灯模式 */
+export function isMusicMarqueeMode(value: unknown): value is MusicMarqueeMode {
+  return value === 'normal' || value === 'rhythm' || value === 'amplitude';
+}

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
@@ -32,6 +32,12 @@ import useIslandStore from '../../../../../../../../store/slices';
 import { SvgIcon } from '../../../../../../../../utils/SvgIcon';
 import { injectFontFace } from '../../../../../../../../utils/font';
 import type { AppSettingsSectionProps } from './types';
+import {
+  MUSIC_OUTER_GLOW_EFFECT_STORE_KEY,
+  MUSIC_MARQUEE_MODE_STORE_KEY,
+  isMusicMarqueeMode,
+} from '../../../../../../lyrics/config/lyricsConstants';
+import type { MusicMarqueeMode } from '../../../../../../lyrics/config/lyricsConstants';
 
 type ThemeSettingsPageProps = Pick<
   AppSettingsSectionProps,
@@ -93,8 +99,6 @@ type ThemeSettingsPageProps = Pick<
   | 'handleAutoDimDelayChange'
 >;
 
-const MUSIC_OUTER_GLOW_EFFECT_STORE_KEY = 'music-outer-glow-effect-enabled';
-const MUSIC_MARQUEE_MODE_STORE_KEY = 'music-marquee-mode';
 const UI_FONT_STORE_KEY = 'ui-font-family';
 const LYRICS_FONT_STORE_KEY = 'lyrics-font-family';
 const UI_CUSTOM_FONTS_STORE_KEY = 'ui-custom-fonts';
@@ -186,7 +190,7 @@ export function ThemeSettingsPage({
   const { t } = useTranslation();
   const setNotification = useIslandStore((s) => s.setNotification);
   const [musicOuterGlowEffectEnabled, setMusicOuterGlowEffectEnabled] = useState<boolean>(true);
-  const [musicMarqueeMode, setMusicMarqueeMode] = useState<'normal' | 'rhythm' | 'amplitude'>('normal');
+  const [musicMarqueeMode, setMusicMarqueeMode] = useState<MusicMarqueeMode>('normal');
   const [uiFont, setUIFont] = useState<string>('default');
   const [lyricsFont, setLyricsFont] = useState<string>('default');
   const [uiCustomFonts, setUiCustomFonts] = useState<CustomFont[]>([]);
@@ -209,7 +213,7 @@ export function ThemeSettingsPage({
     }).catch(() => {});
     window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
       if (cancelled) return;
-      if (value === 'normal' || value === 'rhythm' || value === 'amplitude') setMusicMarqueeMode(value);
+      if (isMusicMarqueeMode(value)) setMusicMarqueeMode(value);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, []);

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
@@ -186,7 +186,7 @@ export function ThemeSettingsPage({
   const { t } = useTranslation();
   const setNotification = useIslandStore((s) => s.setNotification);
   const [musicOuterGlowEffectEnabled, setMusicOuterGlowEffectEnabled] = useState<boolean>(true);
-  const [musicMarqueeMode, setMusicMarqueeMode] = useState<'normal' | 'rhythm'>('normal');
+  const [musicMarqueeMode, setMusicMarqueeMode] = useState<'normal' | 'rhythm' | 'amplitude'>('normal');
   const [uiFont, setUIFont] = useState<string>('default');
   const [lyricsFont, setLyricsFont] = useState<string>('default');
   const [uiCustomFonts, setUiCustomFonts] = useState<CustomFont[]>([]);
@@ -209,7 +209,7 @@ export function ThemeSettingsPage({
     }).catch(() => {});
     window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
       if (cancelled) return;
-      if (value === 'normal' || value === 'rhythm') setMusicMarqueeMode(value);
+      if (value === 'normal' || value === 'rhythm' || value === 'amplitude') setMusicMarqueeMode(value);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, []);
@@ -337,9 +337,9 @@ export function ThemeSettingsPage({
                 {t('settings.app.theme.musicOuterGlowToggle', { defaultValue: '启用歌曲播放外光圈跑马灯特效' })}
               </label>
             </div>
-            <div className="settings-music-hint">{t('settings.app.theme.musicMarqueeModeHint', { defaultValue: '律动模式会让跑马灯跟随当前音频鼓点增强闪烁' })}</div>
+            <div className="settings-music-hint">{t('settings.app.theme.musicMarqueeModeHint', { defaultValue: '律动模式按节拍闪烁，振幅模式根据采样强度调整向内振动幅度' })}</div>
             <div className="settings-lyrics-source-options">
-              {(['normal', 'rhythm'] as const).map((mode) => (
+              {(['normal', 'rhythm', 'amplitude'] as const).map((mode) => (
                 <button
                   key={mode}
                   className={`settings-lyrics-source-btn ${musicMarqueeMode === mode ? 'active' : ''}`}
@@ -351,7 +351,7 @@ export function ThemeSettingsPage({
                   }}
                 >
                   {t(`settings.app.theme.musicMarqueeModeOptions.${mode}`, {
-                    defaultValue: mode === 'normal' ? '普通模式' : '律动模式',
+                    defaultValue: mode === 'normal' ? '普通模式' : mode === 'rhythm' ? '律动模式' : '振幅模式',
                   })}
                 </button>
               ))}

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
@@ -94,6 +94,7 @@ type ThemeSettingsPageProps = Pick<
 >;
 
 const MUSIC_OUTER_GLOW_EFFECT_STORE_KEY = 'music-outer-glow-effect-enabled';
+const MUSIC_MARQUEE_MODE_STORE_KEY = 'music-marquee-mode';
 const UI_FONT_STORE_KEY = 'ui-font-family';
 const LYRICS_FONT_STORE_KEY = 'lyrics-font-family';
 const UI_CUSTOM_FONTS_STORE_KEY = 'ui-custom-fonts';
@@ -185,6 +186,7 @@ export function ThemeSettingsPage({
   const { t } = useTranslation();
   const setNotification = useIslandStore((s) => s.setNotification);
   const [musicOuterGlowEffectEnabled, setMusicOuterGlowEffectEnabled] = useState<boolean>(true);
+  const [musicMarqueeMode, setMusicMarqueeMode] = useState<'normal' | 'rhythm'>('normal');
   const [uiFont, setUIFont] = useState<string>('default');
   const [lyricsFont, setLyricsFont] = useState<string>('default');
   const [uiCustomFonts, setUiCustomFonts] = useState<CustomFont[]>([]);
@@ -204,6 +206,10 @@ export function ThemeSettingsPage({
       if (typeof value === 'boolean') {
         setMusicOuterGlowEffectEnabled(value);
       }
+    }).catch(() => {});
+    window.api.storeRead(MUSIC_MARQUEE_MODE_STORE_KEY).then((value) => {
+      if (cancelled) return;
+      if (value === 'normal' || value === 'rhythm') setMusicMarqueeMode(value);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, []);
@@ -330,6 +336,25 @@ export function ThemeSettingsPage({
                 />
                 {t('settings.app.theme.musicOuterGlowToggle', { defaultValue: '启用歌曲播放外光圈跑马灯特效' })}
               </label>
+            </div>
+            <div className="settings-music-hint">{t('settings.app.theme.musicMarqueeModeHint', { defaultValue: '律动模式会让跑马灯跟随当前音频鼓点增强闪烁' })}</div>
+            <div className="settings-lyrics-source-options">
+              {(['normal', 'rhythm'] as const).map((mode) => (
+                <button
+                  key={mode}
+                  className={`settings-lyrics-source-btn ${musicMarqueeMode === mode ? 'active' : ''}`}
+                  type="button"
+                  onClick={() => {
+                    setMusicMarqueeMode(mode);
+                    window.api.storeWrite(MUSIC_MARQUEE_MODE_STORE_KEY, mode).catch(() => {});
+                    window.dispatchEvent(new CustomEvent('music-marquee-mode-changed', { detail: mode }));
+                  }}
+                >
+                  {t(`settings.app.theme.musicMarqueeModeOptions.${mode}`, {
+                    defaultValue: mode === 'normal' ? '普通模式' : '律动模式',
+                  })}
+                </button>
+              ))}
             </div>
           </div>
         </div>

--- a/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
+++ b/src/renderer/components/states/maxExpand/components/setting/components/app/components/ThemeSettingsPage.tsx
@@ -318,25 +318,31 @@ export function ThemeSettingsPage({
             ))}
           </div>
 
+        </div>
+
+        <div className="settings-card">
+          <div className="settings-card-header">
+            <div className="settings-card-title">{t('settings.app.theme.musicOuterGlowTitle', { defaultValue: '音乐外光圈特效' })}</div>
+            <div className="settings-card-subtitle">{t('settings.app.theme.musicOuterGlowHint', { defaultValue: '控制歌曲播放时专辑封面外圈的跑马灯/光晕动态效果。' })}</div>
+          </div>
+          <div className="settings-card-inline-row">
+            <label className="settings-card-check">
+              <input
+                type="checkbox"
+                checked={musicOuterGlowEffectEnabled}
+                onChange={(event) => {
+                  const next = event.target.checked;
+                  setMusicOuterGlowEffectEnabled(next);
+                  window.api.storeWrite(MUSIC_OUTER_GLOW_EFFECT_STORE_KEY, next).catch(() => {});
+                  window.api.settingsPreview(`store:${MUSIC_OUTER_GLOW_EFFECT_STORE_KEY}`, next).catch(() => {});
+                  window.dispatchEvent(new CustomEvent('music-outer-glow-effect-changed', { detail: next }));
+                }}
+              />
+              {t('settings.app.theme.musicOuterGlowToggle', { defaultValue: '启用歌曲播放外光圈跑马灯特效' })}
+            </label>
+          </div>
           <div className="settings-card-subgroup" style={{ marginTop: 10 }}>
-            <div className="settings-card-subgroup-title">{t('settings.app.theme.musicOuterGlowTitle', { defaultValue: '音乐外光圈特效' })}</div>
-            <div className="settings-music-hint">{t('settings.app.theme.musicOuterGlowHint', { defaultValue: '控制歌曲播放时专辑封面外圈的跑马灯/光晕动态效果。' })}</div>
-            <div className="settings-card-inline-row">
-              <label className="settings-card-check">
-                <input
-                  type="checkbox"
-                  checked={musicOuterGlowEffectEnabled}
-                  onChange={(event) => {
-                    const next = event.target.checked;
-                    setMusicOuterGlowEffectEnabled(next);
-                    window.api.storeWrite(MUSIC_OUTER_GLOW_EFFECT_STORE_KEY, next).catch(() => {});
-                    window.api.settingsPreview(`store:${MUSIC_OUTER_GLOW_EFFECT_STORE_KEY}`, next).catch(() => {});
-                    window.dispatchEvent(new CustomEvent('music-outer-glow-effect-changed', { detail: next }));
-                  }}
-                />
-                {t('settings.app.theme.musicOuterGlowToggle', { defaultValue: '启用歌曲播放外光圈跑马灯特效' })}
-              </label>
-            </div>
+            <div className="settings-card-subgroup-title">{t('settings.app.theme.musicMarqueeModeTitle', { defaultValue: '跑马灯模式' })}</div>
             <div className="settings-music-hint">{t('settings.app.theme.musicMarqueeModeHint', { defaultValue: '律动模式按节拍闪烁，振幅模式根据采样强度调整向内振动幅度' })}</div>
             <div className="settings-lyrics-source-options">
               {(['normal', 'rhythm', 'amplitude'] as const).map((mode) => (

--- a/src/renderer/styles/shell/shell.css
+++ b/src/renderer/styles/shell/shell.css
@@ -599,28 +599,32 @@
 }
 
 .island-shell.music-glow.music-glow-rhythm::after {
-  padding: 3px;
-  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.72);
-  filter: brightness(1.15);
+  padding: 2px;
+  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.48);
+  opacity: 0.82;
+  filter: brightness(1.05);
   animation: none;
 }
 
 .island-shell.music-glow.music-glow-rhythm.music-glow-beat::after {
-  animation: music-glow-beat-pulse 180ms ease-out;
+  animation: music-glow-beat-pulse 280ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @keyframes music-glow-beat-pulse {
   0% {
-    padding: 3px;
-    filter: brightness(1.15);
+    padding: 2px;
+    opacity: 0.82;
+    filter: brightness(1.05);
   }
-  45% {
-    padding: 10px;
-    filter: brightness(2);
+  40% {
+    padding: 6px;
+    opacity: 0.96;
+    filter: brightness(1.35);
   }
   100% {
-    padding: 3px;
-    filter: brightness(1.15);
+    padding: 2px;
+    opacity: 0.82;
+    filter: brightness(1.05);
   }
 }
 

--- a/src/renderer/styles/shell/shell.css
+++ b/src/renderer/styles/shell/shell.css
@@ -628,7 +628,15 @@
   }
 }
 
-/** 跑马灯旋转动画 */
+.island-shell.music-glow.music-glow-amplitude::after {
+  padding: var(--music-glow-inset, 2px);
+  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.55);
+  opacity: var(--music-glow-opacity, 0.45);
+  filter: brightness(1.08);
+  transition: padding 70ms linear, opacity 70ms linear;
+  animation: none;
+}
+
 @keyframes music-glow-rotate {
   to {
     --glow-angle: 360deg;

--- a/src/renderer/styles/shell/shell.css
+++ b/src/renderer/styles/shell/shell.css
@@ -617,7 +617,7 @@
     filter: brightness(1.05);
   }
   40% {
-    padding: 6px;
+    padding: 4px;
     opacity: 0.99;
     filter: brightness(1.35);
   }

--- a/src/renderer/styles/shell/shell.css
+++ b/src/renderer/styles/shell/shell.css
@@ -600,8 +600,8 @@
 
 .island-shell.music-glow.music-glow-rhythm::after {
   padding: 2px;
-  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.48);
-  opacity: 0.82;
+  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.62);
+  opacity: 0.9;
   filter: brightness(1.05);
   animation: none;
 }
@@ -613,25 +613,25 @@
 @keyframes music-glow-beat-pulse {
   0% {
     padding: 2px;
-    opacity: 0.82;
+    opacity: 0.9;
     filter: brightness(1.05);
   }
   40% {
     padding: 6px;
-    opacity: 0.96;
+    opacity: 0.99;
     filter: brightness(1.35);
   }
   100% {
     padding: 2px;
-    opacity: 0.82;
+    opacity: 0.9;
     filter: brightness(1.05);
   }
 }
 
 .island-shell.music-glow.music-glow-amplitude::after {
   padding: var(--music-glow-inset, 2px);
-  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.55);
-  opacity: var(--music-glow-opacity, 0.45);
+  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.68);
+  opacity: var(--music-glow-opacity, 0.62);
   filter: brightness(1.08);
   transition: padding 70ms linear, opacity 70ms linear;
   animation: none;

--- a/src/renderer/styles/shell/shell.css
+++ b/src/renderer/styles/shell/shell.css
@@ -598,6 +598,32 @@
   z-index: 2;
 }
 
+.island-shell.music-glow.music-glow-rhythm::after {
+  padding: 3px;
+  background: rgba(var(--glow-r), var(--glow-g), var(--glow-b), 0.72);
+  filter: brightness(1.15);
+  animation: none;
+}
+
+.island-shell.music-glow.music-glow-rhythm.music-glow-beat::after {
+  animation: music-glow-beat-pulse 180ms ease-out;
+}
+
+@keyframes music-glow-beat-pulse {
+  0% {
+    padding: 3px;
+    filter: brightness(1.15);
+  }
+  45% {
+    padding: 10px;
+    filter: brightness(2);
+  }
+  100% {
+    padding: 3px;
+    filter: brightness(1.15);
+  }
+}
+
 /** 跑马灯旋转动画 */
 @keyframes music-glow-rotate {
   to {


### PR DESCRIPTION
## Verification

- [ ] Verified locally (features / build / regression)

## Frontend Standards Full Checklist (required)

> Standards: `docs/FRONTEND_STANDARDS.md`
>
> Comment standards: `docs/COMMENT_STANDARDS.md`
>
> The following 6 items are enforced by the `PR Code Quality Review` workflow and must be checked.

- [ ] STD-1-HTML Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 1 HTML Standards
- [ ] STD-2-CSS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 2 CSS Standards
- [ ] STD-3-JSTS Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 3 JavaScript / TypeScript Standards
- [ ] STD-4-REACT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 4 React Standards
- [ ] STD-5-NEXT Verified all clauses in docs/FRONTEND_STANDARDS.md Chapter 5 Next.js Standards (if applicable)
- [ ] STD-COMMENT Verified all clauses in docs/COMMENT_STANDARDS.md

## Impact Scope

- [ ] Renderer (`src/renderer`)
- [ ] Main Process (`src/main`)
- [ ] Preload (`src/preload`)
- [ ] Docs / Workflows
- [ ] Other:

## Summary by Sourcery

Add new beat‑driven and amplitude‑driven marquee glow modes for the music outer ring, powered by a Windows audio beat analyzer and exposed through theme settings and IPC.

New Features:
- Introduce selectable marquee modes (normal, rhythm, amplitude) for the music outer glow effect, with per‑mode visual behavior tied to beat pulses or amplitude.
- Add theme settings UI and persisted configuration for choosing the music marquee mode.
- Expose preload APIs and IPC channels to start, poll and stop music beat analysis, returning frequency, amplitude and beat metadata.
- Implement resolution of the current SMTC source to the corresponding active audio process to drive beat analysis across common music players and browsers.

Enhancements:
- Integrate music beat analysis into the Dynamic Island shell presentation to modulate glow classes and CSS variables for rhythm and amplitude modes.
- Refine the music glow CSS to support rhythm pulse animation and amplitude‑based inset/opacity transitions.
- Extend media IPC to trigger audio analyzer restart when the user switches playback sources.

Tests:
- Add unit tests for resolving SMTC music sources to active audio processes, including alias and fallback scenarios.
- Update media and music IPC handler tests to cover the new marquee beat channels and increased handler count.